### PR TITLE
ASU-541: added boolean fields for apartments, publish on etuovi / oikotie

### DIFF
--- a/conf/cmi/core.entity_form_display.node.apartment.default.yml
+++ b/conf/cmi/core.entity_form_display.node.apartment.default.yml
@@ -26,6 +26,8 @@ dependencies:
     - field.field.node.apartment.field_other_fees
     - field.field.node.apartment.field_parking_fee
     - field.field.node.apartment.field_parking_fee_explanation
+    - field.field.node.apartment.field_publish_on_etuovi
+    - field.field.node.apartment.field_publish_on_oikotie
     - field.field.node.apartment.field_room_count
     - field.field.node.apartment.field_sales_price
     - field.field.node.apartment.field_services_description
@@ -299,6 +301,20 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: string_textarea
+    region: content
+  field_publish_on_etuovi:
+    weight: 36
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+  field_publish_on_oikotie:
+    weight: 37
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
     region: content
   field_room_count:
     weight: 15

--- a/conf/cmi/core.entity_view_display.node.apartment.default.yml
+++ b/conf/cmi/core.entity_view_display.node.apartment.default.yml
@@ -26,6 +26,8 @@ dependencies:
     - field.field.node.apartment.field_other_fees
     - field.field.node.apartment.field_parking_fee
     - field.field.node.apartment.field_parking_fee_explanation
+    - field.field.node.apartment.field_publish_on_etuovi
+    - field.field.node.apartment.field_publish_on_oikotie
     - field.field.node.apartment.field_room_count
     - field.field.node.apartment.field_sales_price
     - field.field.node.apartment.field_services_description
@@ -264,6 +266,26 @@ content:
     third_party_settings: {  }
     type: basic_string
     region: content
+  field_publish_on_etuovi:
+    weight: 54
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
+  field_publish_on_oikotie:
+    weight: 55
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
   field_room_count:
     weight: 7
     label: inline
@@ -364,6 +386,8 @@ content:
     third_party_settings: {  }
 hidden:
   asu_computed_apartment_images: true
+  asu_project_building_type: true
+  asu_project_holding_type: true
   asu_state_of_sale: true
   field_apartment_address: true
   field_apartment_holding_type: true

--- a/conf/cmi/core.entity_view_display.node.apartment.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.apartment.teaser.yml
@@ -27,6 +27,8 @@ dependencies:
     - field.field.node.apartment.field_other_fees
     - field.field.node.apartment.field_parking_fee
     - field.field.node.apartment.field_parking_fee_explanation
+    - field.field.node.apartment.field_publish_on_etuovi
+    - field.field.node.apartment.field_publish_on_oikotie
     - field.field.node.apartment.field_room_count
     - field.field.node.apartment.field_sales_price
     - field.field.node.apartment.field_services_description
@@ -52,6 +54,8 @@ content:
     region: content
 hidden:
   asu_computed_apartment_images: true
+  asu_project_building_type: true
+  asu_project_holding_type: true
   asu_state_of_sale: true
   field_acc_financeofficer: true
   field_acc_salesperson: true
@@ -102,6 +106,8 @@ hidden:
   field_price_m2: true
   field_project_manager: true
   field_publication_end_time: true
+  field_publish_on_etuovi: true
+  field_publish_on_oikotie: true
   field_room_count: true
   field_sales_price: true
   field_services_description: true

--- a/conf/cmi/field.field.node.apartment.field_publish_on_etuovi.yml
+++ b/conf/cmi/field.field.node.apartment.field_publish_on_etuovi.yml
@@ -1,0 +1,23 @@
+uuid: 6a4e8638-ccee-4a6f-a934-33a670a19f0e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_publish_on_etuovi
+    - node.type.apartment
+id: node.apartment.field_publish_on_etuovi
+field_name: field_publish_on_etuovi
+entity_type: node
+bundle: apartment
+label: 'Publish on etuovi'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'True'
+  off_label: 'False'
+field_type: boolean

--- a/conf/cmi/field.field.node.apartment.field_publish_on_oikotie.yml
+++ b/conf/cmi/field.field.node.apartment.field_publish_on_oikotie.yml
@@ -1,0 +1,23 @@
+uuid: 82faed77-ea36-47bd-bb93-0e2357b6454b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_publish_on_oikotie
+    - node.type.apartment
+id: node.apartment.field_publish_on_oikotie
+field_name: field_publish_on_oikotie
+entity_type: node
+bundle: apartment
+label: 'Publish on oikotie'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'True'
+  off_label: 'False'
+field_type: boolean

--- a/conf/cmi/field.storage.node.field_publish_on_etuovi.yml
+++ b/conf/cmi/field.storage.node.field_publish_on_etuovi.yml
@@ -1,0 +1,18 @@
+uuid: 030530ba-3eb6-4201-872a-2cf6b8519683
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_publish_on_etuovi
+field_name: field_publish_on_etuovi
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_publish_on_oikotie.yml
+++ b/conf/cmi/field.storage.node.field_publish_on_oikotie.yml
@@ -1,0 +1,18 @@
+uuid: 6012d210-5cdd-44f1-b9a1-2165cb4bc0a8
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_publish_on_oikotie
+field_name: field_publish_on_oikotie
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/search_api.index.apartment.yml
+++ b/conf/cmi/search_api.index.apartment.yml
@@ -22,6 +22,8 @@ dependencies:
     - field.storage.node.field_other_fees
     - field.storage.node.field_parking_fee
     - field.storage.node.field_parking_fee_explanation
+    - field.storage.node.field_publish_on_etuovi
+    - field.storage.node.field_publish_on_oikotie
     - field.storage.node.field_sales_price
     - field.storage.node.field_has_apartment_sauna
     - field.storage.node.field_services_description
@@ -547,6 +549,22 @@ field_settings:
     datasource_id: 'entity:node'
     property_path: 'search_api_reverse_entity_references_node__field_apartments:field_zoning_status'
     type: string
+  publish_on_etuovi:
+    label: 'Publish on etuovi'
+    datasource_id: 'entity:node'
+    property_path: field_publish_on_etuovi
+    type: boolean
+    dependencies:
+      config:
+        - field.storage.node.field_publish_on_etuovi
+  publish_on_oikotie:
+    label: 'Publish on oikotie'
+    datasource_id: 'entity:node'
+    property_path: field_publish_on_oikotie
+    type: boolean
+    dependencies:
+      config:
+        - field.storage.node.field_publish_on_oikotie
   room_count:
     label: 'Number of rooms'
     datasource_id: 'entity:node'


### PR DESCRIPTION
Added boolean fields enabling users to publish any apartment on oikotie or etuovi

Test:
Apartment should have fields for etuovi and oikotie (field_publish_on_{})
Elasticsearch index should have publish_on_{} boolean fields
