### PR TITLE
ASU-667: Automatic state change when apartment is set as sold.

### DIFF
--- a/public/modules/custom/asu_content/asu_content.module
+++ b/public/modules/custom/asu_content/asu_content.module
@@ -76,6 +76,17 @@ function asu_content_entity_presave(EntityInterface $entity) {
       }
 
       $entity->setTitle($title);
+
+      // When sold, unpulish apartment.
+      // Unpublishing removes apartment from elasticsearch.
+      if ($entity->isPublished()) {
+        $tids = taxonomy_term_load_multiple_by_name('sold', 'apartment_state_of_sale');
+        // Get the id of sold state.
+        if (!empty($tids) && $entity->field_apartment_state_of_sale->target_id == reset($tids)->id()) {
+          $entity->setUnpublished();
+          \Drupal::messenger()->addMessage(t("Apartment @title was sold and is now unpublished.", ['@title' => $entity->title->value]));
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Apartment is set unpublished when state of sale is set to sold

Make fresh (although drush cr should be enough)

What to do:
- Go to any apartment edit page
- Change the state of sale to "Sold"
- Save the entity
 
You should see:
After saving you should see a message telling that the apartment was unpublished
The entity should be unpublished