### PR TITLE
Asu 735 create dummy apartment on project creation

### DIFF
--- a/conf/cmi/field.field.node.apartment.field_debt_free_sales_price.yml
+++ b/conf/cmi/field.field.node.apartment.field_debt_free_sales_price.yml
@@ -13,7 +13,9 @@ label: 'Debt free sales price'
 description: ''
 required: false
 translatable: false
-default_value: {  }
+default_value:
+  -
+    value: !!float 0
 default_value_callback: ''
 settings:
   min: null

--- a/conf/cmi/field.field.node.apartment.field_floor.yml
+++ b/conf/cmi/field.field.node.apartment.field_floor.yml
@@ -13,7 +13,9 @@ label: Floor
 description: ''
 required: false
 translatable: false
-default_value: {  }
+default_value:
+  -
+    value: 1
 default_value_callback: ''
 settings:
   min: null

--- a/conf/cmi/field.field.node.apartment.field_floor_max.yml
+++ b/conf/cmi/field.field.node.apartment.field_floor_max.yml
@@ -13,7 +13,9 @@ label: 'Total number of floors in the building'
 description: ''
 required: false
 translatable: false
-default_value: {  }
+default_value:
+  -
+    value: 1
 default_value_callback: ''
 settings:
   min: null

--- a/conf/cmi/field.field.node.apartment.field_living_area.yml
+++ b/conf/cmi/field.field.node.apartment.field_living_area.yml
@@ -13,7 +13,9 @@ label: 'Living area'
 description: ''
 required: false
 translatable: false
-default_value: {  }
+default_value:
+  -
+    value: !!float 0
 default_value_callback: ''
 settings:
   min: null

--- a/conf/cmi/field.field.node.apartment.field_loan_share.yml
+++ b/conf/cmi/field.field.node.apartment.field_loan_share.yml
@@ -13,7 +13,9 @@ label: 'Share of housing company loan'
 description: ''
 required: false
 translatable: false
-default_value: {  }
+default_value:
+  -
+    value: !!float 0
 default_value_callback: ''
 settings:
   min: null

--- a/conf/cmi/field.field.node.apartment.field_maintenance_fee.yml
+++ b/conf/cmi/field.field.node.apartment.field_maintenance_fee.yml
@@ -13,11 +13,13 @@ label: 'Maintenance fee'
 description: ''
 required: false
 translatable: false
-default_value: {  }
+default_value:
+  -
+    value: !!float 0
 default_value_callback: ''
 settings:
   min: null
   max: null
   prefix: ''
-  suffix: '€ / month'
+  suffix: '€ / kk'
 field_type: decimal

--- a/conf/cmi/field.field.node.apartment.field_parking_fee.yml
+++ b/conf/cmi/field.field.node.apartment.field_parking_fee.yml
@@ -13,11 +13,13 @@ label: 'Parking fee'
 description: ''
 required: false
 translatable: false
-default_value: {  }
+default_value:
+  -
+    value: !!float 0
 default_value_callback: ''
 settings:
   min: null
   max: null
   prefix: ''
-  suffix: '€ / month'
+  suffix: '€ / kk'
 field_type: decimal

--- a/conf/cmi/field.field.node.apartment.field_room_count.yml
+++ b/conf/cmi/field.field.node.apartment.field_room_count.yml
@@ -13,7 +13,9 @@ label: 'Number of rooms'
 description: ''
 required: false
 translatable: false
-default_value: {  }
+default_value:
+  -
+    value: 0
 default_value_callback: ''
 settings:
   min: null

--- a/conf/cmi/field.field.node.apartment.field_sales_price.yml
+++ b/conf/cmi/field.field.node.apartment.field_sales_price.yml
@@ -13,7 +13,9 @@ label: 'Sales price'
 description: ''
 required: false
 translatable: false
-default_value: {  }
+default_value:
+  -
+    value: !!float 0
 default_value_callback: ''
 settings:
   min: null

--- a/conf/cmi/field.field.node.apartment.field_stock_end_number.yml
+++ b/conf/cmi/field.field.node.apartment.field_stock_end_number.yml
@@ -13,7 +13,9 @@ label: 'Stock end number'
 description: ''
 required: false
 translatable: true
-default_value: {  }
+default_value:
+  -
+    value: 1
 default_value_callback: ''
 settings:
   min: 1

--- a/conf/cmi/field.field.node.apartment.field_water_fee.yml
+++ b/conf/cmi/field.field.node.apartment.field_water_fee.yml
@@ -13,7 +13,9 @@ label: 'Water fee'
 description: ''
 required: false
 translatable: false
-default_value: {  }
+default_value:
+  -
+    value: !!float 0
 default_value_callback: ''
 settings:
   min: null

--- a/public/modules/custom/asu_content/asu_content.module
+++ b/public/modules/custom/asu_content/asu_content.module
@@ -137,7 +137,7 @@ function asu_content_node_insert(Node $node) {
       $apartment->save();
 
       $node->get('field_apartments');
-      $node->field_apartments->setValue([$node]);
+      $node->field_apartments->setValue([$apartment]);
       $node->save();
     }
   }

--- a/public/modules/custom/asu_content/asu_content.module
+++ b/public/modules/custom/asu_content/asu_content.module
@@ -5,11 +5,6 @@
  * Contains asu_content.module.
  */
 
-const FORMS_TO_HIDE_TITLE_FROM = [
-  'node_apartment_edit_form',
-  'node_apartment_form',
-];
-
 use Drupal\asu_content\ProjectUpdater;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
@@ -46,7 +41,12 @@ function asu_content_form_alter(&$form, $form_state) {
  * {@inheritDoc}
  */
 function asu_content_hide_node_title(&$form, $form_state) {
-  if (!in_array($form['#form_id'], FORMS_TO_HIDE_TITLE_FROM)) {
+  $forms_to_hide_title_from = [
+    'node_apartment_edit_form',
+    'node_apartment_form',
+  ];
+
+  if (!in_array($form['#form_id'], $forms_to_hide_title_from)) {
     return;
   }
 
@@ -83,9 +83,16 @@ function asu_content_entity_presave(EntityInterface $entity) {
       if ($entity->isPublished()) {
         $tids = taxonomy_term_load_multiple_by_name('sold', 'apartment_state_of_sale');
         // Get the id of sold state.
-        if (!empty($tids) && $entity->field_apartment_state_of_sale->target_id == reset($tids)->id()) {
+        if (
+          !empty($tids) &&
+          $entity->field_apartment_state_of_sale->target_id == reset($tids)->id()
+        ) {
           $entity->setUnpublished();
-          \Drupal::messenger()->addMessage(t("Apartment @title was sold and is now unpublished.", ['@title' => $entity->title->value]));
+          \Drupal::messenger()->addMessage(
+            t("Apartment @title was sold and is now unpublished.",
+              ['@title' => $entity->title->value]
+            )
+          );
         }
       }
     }
@@ -113,6 +120,30 @@ function asu_content_entity_update($entity) {
 }
 
 /**
+ * Implements hook_node_insert().
+ */
+function asu_content_node_insert(Node $node) {
+  if (
+    method_exists($node, 'getType') &&
+    $node->getType() == 'project' &&
+    $node->hasField('field_apartments')
+  ) {
+    if ($node->field_apartments->isEmpty()) {
+      $apartment = Node::create([
+        'type' => 'apartment',
+        'title' => '',
+        'field_apartment_number' => 'A0',
+      ]);
+      $apartment->save();
+
+      $node->get('field_apartments');
+      $node->field_apartments->setValue([$node]);
+      $node->save();
+    }
+  }
+}
+
+/**
  * Implements hook_cron().
  */
 function asu_content_cron() {
@@ -135,9 +166,9 @@ function asu_content_cron() {
     }
     catch (\Exception $e) {
       // The time is most likely not set.
-      // @Todo: logging.
+      // @todo Logging.
     }
   }
-  // @Todo: logging.
+  // @todo Logging.
   // Log updated ids
 }

--- a/public/modules/custom/asu_content/asu_content.module
+++ b/public/modules/custom/asu_content/asu_content.module
@@ -133,6 +133,7 @@ function asu_content_node_insert(Node $node) {
         'type' => 'apartment',
         'title' => '',
         'field_apartment_number' => 'A0',
+        'status' => 0
       ]);
       $apartment->save();
 

--- a/public/modules/custom/asu_content/src/Plugin/ComputedField/PricePerSquareMeter.php
+++ b/public/modules/custom/asu_content/src/Plugin/ComputedField/PricePerSquareMeter.php
@@ -41,7 +41,11 @@ class PricePerSquareMeter extends FieldItemList {
         $value = 0;
       }
       else {
-        $value = number_format((float) $price / $living_area, 2, '.', '');
+        if($price == 0 || $living_area == 0){
+          $value = 0;
+        } else {
+          $value = number_format((float) $price / $living_area, 2, '.', '');
+        }
       }
     }
 

--- a/public/modules/custom/asu_content/src/Plugin/ComputedField/PricePerSquareMeter.php
+++ b/public/modules/custom/asu_content/src/Plugin/ComputedField/PricePerSquareMeter.php
@@ -41,9 +41,10 @@ class PricePerSquareMeter extends FieldItemList {
         $value = 0;
       }
       else {
-        if($price == 0 || $living_area == 0){
+        if ($price == 0 || $living_area == 0) {
           $value = 0;
-        } else {
+        }
+        else {
           $value = number_format((float) $price / $living_area, 2, '.', '');
         }
       }

--- a/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
+++ b/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
@@ -74,7 +74,7 @@ function asuntotuotanto_preprocess_menu(&$variables) {
 
       if ($menu_block_configuration_suggestion === 'main__desktop') {
         $items = $variables['items'];
-        $current_path =  Url::fromRoute('<current>')->toString();
+        $current_path = Url::fromRoute('<current>')->toString();
 
         foreach ($items as $key => $item) {
           $is_active = FALSE;
@@ -109,7 +109,7 @@ function asuntotuotanto_preprocess_menu(&$variables) {
 
       foreach ($items as $key => $item) {
         $url = $item['url']->toString();
-        $current_path =  Url::fromRoute('<current>')->toString();
+        $current_path = Url::fromRoute('<current>')->toString();
         $is_active = $current_path === $url;
         $variables['items']['asu_user_tools_menu.user_name']['below'][$key]['is_link_active'] = $is_active;
       }
@@ -136,10 +136,10 @@ function asuntotuotanto_preprocess_node(&$variables) {
       foreach ($apartments as $key => $apartment) {
         $apartment_target_id = $apartment['target_id'];
         $apartment_node = Node::load($apartment_target_id);
-        $apartment_sales_price = $apartment_node->get('field_sales_price')->value;
-        $apartment_debt_free_sales_price = $apartment_node->get('field_debt_free_sales_price')->value;
-        $apartment_living_area_size = $apartment_node->get('field_living_area')->value;
-        $apartment_structure = $apartment_node->get('field_apartment_structure')->value;
+        $apartment_sales_price = $apartment_node->hasField('field_sales_price') ? $apartment_node->get('field_sales_price')->value : 0;
+        $apartment_debt_free_sales_price = $apartment_node->hasField('field_debt_free_sales_price') ? $apartment_node->get('field_debt_free_sales_price')->value : 0;
+        $apartment_living_area_size = $apartment_node->hasField('field_living_area') ? $apartment_node->get('field_living_area')->value : 0;
+        $apartment_structure = $apartment_node->hasField('field_apartment_structure') ? $apartment_node->get('field_apartment_structure')->value : 0;
 
         array_push($apartment_sales_prices, $apartment_sales_price);
         array_push($apartment_debt_free_sales_prices, $apartment_debt_free_sales_price);
@@ -147,26 +147,36 @@ function asuntotuotanto_preprocess_node(&$variables) {
         array_push($apartment_structures, $apartment_structure);
       }
 
-      sort($apartment_structures);
+      $apartment_debt_free_sales_prices_string = '';
+      $apartment_sales_prices_string = '';
 
-      $apartment_debt_free_sales_prices_minmax = [
-        "min" => number_format(min($apartment_debt_free_sales_prices), 2, ',', '.'),
-        "max" => number_format(max($apartment_debt_free_sales_prices), 2, ',', '.'),
-      ];
+      if (isset($apartment_structures)) {
+        sort($apartment_structures);
+      }
 
-      $apartment_sales_prices_minmax = [
-        "min" => number_format(min($apartment_sales_prices), 2, ',', '.'),
-        "max" => number_format(max($apartment_sales_prices), 2, ',', '.'),
-      ];
+      if (!empty($apartment_debt_free_sales_prices)) {
+        $apartment_debt_free_sales_prices_minmax = [
+          "min" => number_format(min($apartment_debt_free_sales_prices), 2, ',', '.'),
+          "max" => number_format(max($apartment_debt_free_sales_prices), 2, ',', '.'),
+        ];
+        $apartment_debt_free_sales_prices_string = $apartment_debt_free_sales_prices_minmax['min'] . " € - " . $apartment_debt_free_sales_prices_minmax['max'] . " €";
+      }
 
-      $apartment_living_area_sizes_minmax = [
-        "min" => number_format(min($apartment_living_area_sizes), 1, ',', NULL),
-        "max" => number_format(max($apartment_living_area_sizes), 1, ',', NULL),
-      ];
+      if (!empty($apartment_sales_prices)) {
+        $apartment_sales_prices_minmax = [
+          "min" => number_format(min($apartment_sales_prices), 2, ',', '.'),
+          "max" => number_format(max($apartment_sales_prices), 2, ',', '.'),
+        ];
+        $apartment_sales_prices_string = $apartment_sales_prices_minmax['min'] . " € - " . $apartment_sales_prices_minmax['max'] . " €";
+      }
 
-      $apartment_debt_free_sales_prices_string = $apartment_debt_free_sales_prices_minmax['min'] . " € - " . $apartment_debt_free_sales_prices_minmax['max'] . " €";
-      $apartment_sales_prices_string = $apartment_sales_prices_minmax['min'] . " € - " . $apartment_sales_prices_minmax['max'] . " €";
-      $apartment_living_area_sizes_string = $apartment_living_area_sizes_minmax['min'] . " - " . $apartment_living_area_sizes_minmax['max'];
+      if (!empty($apartment_living_area_sizes)) {
+        $apartment_living_area_sizes_minmax = [
+          "min" => number_format(min($apartment_living_area_sizes), 1, ',', NULL),
+          "max" => number_format(max($apartment_living_area_sizes), 1, ',', NULL),
+        ];
+        $apartment_living_area_sizes_string = $apartment_living_area_sizes_minmax['min'] . " - " . $apartment_living_area_sizes_minmax['max'];
+      }
 
       $services = $node->get('field_services')->getValue();
       $services_stack = [];
@@ -229,7 +239,7 @@ function asuntotuotanto_preprocess_node(&$variables) {
       $variables['apartment_sales_prices'] = $apartment_sales_prices_string;
       $variables['apartment_debt_free_sales_prices'] = $apartment_debt_free_sales_prices_string;
       $variables['apartment_structures'] = implode(", ", array_unique($apartment_structures));
-      $variables['apartment_living_area_sizes_m2'] = $apartment_living_area_sizes_string;
+      $variables['apartment_living_area_sizes_m2'] = $apartment_living_area_sizes_string ?? '';
       $variables['attachments'] = $attachments_stack ?? NULL;
       $variables['services'] = $services_stack ?? NULL;
       $variables['estimated_completion_date'] = $estimated_completion_date->format('m/Y') ?? NULL;


### PR DESCRIPTION
Creates dummy apartment for project if no apartments are added to the new project.

Make fresh

Create new Project (with no field values)
Save the project
Open the newly created project
 - Apartment list should have 1 apartment with empty dataset (created automatically)

Create another new project
This time use the Project create form's entity reference tool to create new apartment for the project 
 - Just add apartment number, no need to add any new values
Save the Project
 - Apartment list should have 1 apartment with the dataset you entered (only the manually created one) 
