### PR TITLE
Fix azure release trigger

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -6,6 +6,7 @@ trigger:
   branches:
     include:
     - release/*
+    - refs/tags/*
   paths:
     exclude:
     - README.md


### PR DESCRIPTION
Making a release didn't trigger the build action on Azure. Compared code to public side, there has been set this change and it worked well.