### PR TITLE
Prevent submit handler from executing if required field is not set

### DIFF
--- a/public/modules/custom/asu_csv_import/asu_csv_import.module
+++ b/public/modules/custom/asu_csv_import/asu_csv_import.module
@@ -69,14 +69,22 @@ function csv_import_download_template(&$form, FormStateInterface $form_state) {
 function asu_csv_import_process($form, FormStateInterface &$form_state) {
   $form_object = $form_state->getFormObject();
   $fields = $form_object->getEntity()->getFields();
-  $langcode = $form_object->getEntity()->langcode->value;
-  $project_apartments_field = $fields['field_apartments'];
   $upload_file_handler = \Drupal::service('asu_csv_import.upload_file_handler');
-
   /** @var \Drupal\file\Entity\File $file */
   if (!$file = $upload_file_handler->getUploadedFile($fields)) {
     return;
   }
+
+  if (!$form_state->getValue('field_housing_company')[0]['value']) {
+    \Drupal::messenger()->addError(t('Cannot perform csv-import if project housing company -field value is not set.'));
+    $file->delete();
+    $form_state->unsetValue('field_import_apartments');
+    $form_object->getEntity()->save();
+    return;
+  }
+
+  $langcode = $form_object->getEntity()->langcode->value;
+  $project_apartments_field = $fields['field_apartments'];
 
   $nodes = $upload_file_handler->createNodes($file, $langcode);
 

--- a/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
+++ b/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
@@ -220,8 +220,10 @@ function asuntotuotanto_preprocess_views_view_table(&$variables) {
 
       $langcode = Drupal::languageManager()->getCurrentLanguage()->getId();
 
+      $ownership_type_entity = $parent_node->get('field_ownership_type')->entity;
+
       $project_id = $parent_node->id();
-      $ownership_type = strtolower($parent_node->get('field_ownership_type')->entity->getName());
+      $ownership_type = $ownership_type_entity ? strtolower($ownership_type_entity->getName()): '';
       $application_url = "/$langcode/application/add/$ownership_type/$project_id";
 
       $variables['rows'][$key]['is_application_period_active'] = $is_application_period_active;


### PR DESCRIPTION
create new project
 - leave all required fields empty
 - add csv to importer
 - save the project

No new apartments were created & added to the project.