### PR TITLE
ASU-1060: Hide empty fields in the apartments details page

### DIFF
--- a/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
@@ -93,405 +93,454 @@
 {% set debt_free_sales_price = content.field_debt_free_sales_price.0 %}
 {% set apartment_number = content.field_apartment_number.0 %}
 
-<article{{ attributes.addClass(classes) }}>
-  <div class="sticky-navigation is-hidden" aria-hidden="true" id="sticky_navigation">
-    <div class="sticky-navigation__container wrapper wrapper--mw-1264">
-      <div class="sticky-navigation__content">
-        <div class="sticky-navigation__content-section">
-          <p class="sticky-navigation__content-item">{{ apartment_number }}</p>
-          <p class="sticky-navigation__content-item sticky-navigation__content-item--separator">
-            {% if apartment_structure|render %}
-              <span>{{ apartment_structure }}</span>
-            {% endif %}
-            <span aria-hidden="true"></span>
-            {% if living_area_size_m2|render %}
-              <span>{{ living_area_size_m2 }} m<sup>2</sup></span>
-            {% endif %}
-          </p>
-        </div>
-        <div class="sticky-navigation__content-section">
-          <p class="sticky-navigation__content-item">
-            Completion {{ estimated_completion_date }}
-          </p>
-          {% if is_application_period_active %}
-            <p class="sticky-navigation__content-item">
-              {% trans %}
-                Application period is open till {{ application_end_time }}
-              {% endtrans %}
-            </p>
-          {% endif %}
-        </div>
-      </div>
-      <nav class="sticky-navigation__anchor-navigation">
-        <ul class="sticky-navigation__anchor-list">
-          <li class="sticky-navigation__anchor-item">
-            <a href="#showcase_gallery" class="sticky-navigation__anchor-link">
-              {% include "@hdbt/misc/icon.twig" with {icon: 'photo-plus', label: ''} %}
-              {% trans %}
-                Images
-              {% endtrans %}
-            </a>
-          </li>
-          <li class="sticky-navigation__anchor-item">
-            <a href="#apartment_information" class="sticky-navigation__anchor-link">
-              {% include "@hdbt/misc/icon.twig" with {icon: 'info-circle', label: ''} %}
-              {% trans %}
-                Information
-              {% endtrans %}
-            </a>
-          </li>
-          {% if attachments|length > 0 %}
-            <li class="sticky-navigation__anchor-item">
-              <a href="#apartment_attachments" class="sticky-navigation__anchor-link">
-                {% include "@asuntotuotanto/misc/icon.twig" with {icon: 'floor-plan', label: ''} %}
-                {% trans %}
-                  Floor plan
-                {% endtrans %}
-              </a>
-            </li>
-          {% endif %}
-          <li class="sticky-navigation__anchor-item">
-            <a href="#apartment_location" class="sticky-navigation__anchor-link">
-              {% include "@hdbt/misc/icon.twig" with {icon: 'location', label: ''} %}
-              {% trans %}
-                Location
-              {% endtrans %}
-            </a>
-          </li>
-        </ul>
-      </nav>
-    </div>
-  </div>
+<article{{attributes.addClass(classes)}}>
+	<div class="sticky-navigation is-hidden" aria-hidden="true" id="sticky_navigation">
+		<div class="sticky-navigation__container wrapper wrapper--mw-1264">
+			<div class="sticky-navigation__content">
+				<div class="sticky-navigation__content-section">
+					<p class="sticky-navigation__content-item">{{ apartment_number }}</p>
+					<p class="sticky-navigation__content-item sticky-navigation__content-item--separator">
+						{% if apartment_structure|render %}
+							<span>{{ apartment_structure }}</span>
+						{% endif %}
+						<span aria-hidden="true"></span>
+						{% if living_area_size_m2|render %}
+							<span>{{ living_area_size_m2 }}
+								m<sup>2</sup>
+							</span>
+						{% endif %}
+					</p>
+				</div>
+				<div class="sticky-navigation__content-section">
+					<p class="sticky-navigation__content-item">
+						Completion
+						{{ estimated_completion_date }}
+					</p>
+					{% if is_application_period_active %}
+						<p class="sticky-navigation__content-item">
+							{% trans %}
+							Application period is open till
+							{{ application_end_time }}
+							{% endtrans %}
+						</p>
+					{% endif %}
+				</div>
+			</div>
+			<nav class="sticky-navigation__anchor-navigation">
+				<ul class="sticky-navigation__anchor-list">
+					<li class="sticky-navigation__anchor-item">
+						<a href="#showcase_gallery" class="sticky-navigation__anchor-link">
+							{% include "@hdbt/misc/icon.twig" with {icon: 'photo-plus', label: ''} %}
+							{% trans %}
+							Images
+							{% endtrans %}
+						</a>
+					</li>
+					<li class="sticky-navigation__anchor-item">
+						<a href="#apartment_information" class="sticky-navigation__anchor-link">
+							{% include "@hdbt/misc/icon.twig" with {icon: 'info-circle', label: ''} %}
+							{% trans %}
+							Information
+							{% endtrans %}
+						</a>
+					</li>
+					{% if attachments|length > 0 %}
+						<li class="sticky-navigation__anchor-item">
+							<a href="#apartment_attachments" class="sticky-navigation__anchor-link">
+								{% include "@asuntotuotanto/misc/icon.twig" with {icon: 'floor-plan', label: ''} %}
+								{% trans %}
+								Floor plan
+								{% endtrans %}
+							</a>
+						</li>
+					{% endif %}
+					<li class="sticky-navigation__anchor-item">
+						<a href="#apartment_location" class="sticky-navigation__anchor-link">
+							{% include "@hdbt/misc/icon.twig" with {icon: 'location', label: ''} %}
+							{% trans %}
+							Location
+							{% endtrans %}
+						</a>
+					</li>
+				</ul>
+			</nav>
+		</div>
+	</div>
 
-  <div class="apartment__header wrapper wrapper--mw-1264">
-    <div class="apartment__header-section apartment__header-section--heading">
-      <h1 class="apartment__label">{{ label }}</h1>
-      {% if apartment_structure|render or living_area_size_m2|render %}
-        <h2 class="apartment__lead">
-          {% if apartment_structure|render %}
-            <span class="apartment__apartment-structure">{{ apartment_structure }}</span>
-          {% endif %}
-          <span aria-hidden="true"></span>
-          {% if living_area_size_m2|render %}
-            <span class="apartment__living-area-size">{{ living_area_size_m2 }} m<sup>2</sup></span>
-          {% endif %}
-        </h2>
-      {% endif %}
-    </div>
-    <div class="apartment__header-section apartment__header-section--actions {{ is_application_period_active ? 'is-application-period-active' }}">
-      {% if is_application_period_active %}
-        {% include '@asuntotuotanto/button/button.html.twig' with {
-          type: 'primary',
-          disabled: false,
-          label: 'Create an application'|t,
-          href: application_url
-          }
-        %}
-      {% elseif is_application_period_in_the_past %}
-        <p>
-          {% trans %}
-            The application period for the project ended on {{ application_end_time }}.
-          {% endtrans %}
-        </p>
-      {% else %}
-        <p>
-          {% trans %}
-            The application period for the project starts on {{ application_start_time }} and ends on {{ application_end_time }}.
-          {% endtrans %}
-        </p>
-      {% endif %}
-    </div>
-  </div>
+	<div class="apartment__header wrapper wrapper--mw-1264">
+		<div class="apartment__header-section apartment__header-section--heading">
+			<h1 class="apartment__label">{{ label }}</h1>
+			{% if apartment_structure|render or living_area_size_m2|render %}
+				<h2 class="apartment__lead">
+					{% if apartment_structure|render %}
+						<span class="apartment__apartment-structure">{{ apartment_structure }}</span>
+					{% endif %}
+					{% if living_area_size_m2|render and living_area_size_m2|render != '0,0' %}
+						<span aria-hidden="true"></span>
+					{% endif %}
+					{% if living_area_size_m2|render and living_area_size_m2|render != '0,0' %}
+						<span class="apartment__living-area-size">{{ living_area_size_m2 }}
+							m<sup>2</sup>
+						</span>
+					{% endif %}
+				</h2>
+			{% endif %}
+		</div>
+		<div class="apartment__header-section apartment__header-section--actions {{ is_application_period_active ? 'is-application-period-active' }}">
+			{% if is_application_period_active %}
+				{% include '@asuntotuotanto/button/button.html.twig' with {
+					type: 'primary',
+					disabled: false,
+					label: 'Create an application'|t,
+					href: application_url
+					}
+        		%}
+			{% elseif is_application_period_in_the_past %}
+				<p>
+					{% trans %}
+						The application period for the project ended on
+						{{ application_end_time }}.
+					{% endtrans %}
+				</p>
+			{% elseif application_start_time == null and application_end_time == null %}
+				{% trans %}
+					No application period specified for the project.
+				{% endtrans %}
+			{% else %}
+				<p>
+					{% trans %}
+						The application period for the project starts on
+						{{ application_start_time }}
+						and ends on
+						{{ application_end_time }}.
+					{% endtrans %}
+				</p>
+			{% endif %}
+		</div>
+	</div>
 
-    <div class="apartment__images wrapper wrapper--mw-1264 showcase-gallery" id="showcase_gallery">
-      {% if not images|render %}
-        <div class="apartment__images--missing"></div>
-      {% endif %}
-      {% if images|render %}
-          {{ images }}
-      {% endif %}
-    </div>
+	<div class="apartment__images wrapper wrapper--mw-1264 showcase-gallery" id="showcase_gallery">
+		{% if not images|render %}
+			<div class="apartment__images--missing"></div>
+		{% endif %}
+		{% if images|render %}
+			{{ images }}
+		{% endif %}
+	</div>
 
-  <nav class="apartment__anchor-navigation apartment__anchor-navigation--desktop wrapper wrapper--mw-1264">
-    <ul class="apartment__anchor-list">
-      <li class="apartment__anchor-item">
-        <a href="#showcase_gallery" class="apartment__anchor-link">
-          {% include "@hdbt/misc/icon.twig" with {icon: 'photo-plus', label: ''} %}
-          {% trans %}
-            Images
-          {% endtrans %}
-        </a>
-      </li>
-      <li class="apartment__anchor-item">
-        <a href="#apartment_information" class="apartment__anchor-link">
-          {% include "@hdbt/misc/icon.twig" with {icon: 'info-circle', label: ''} %}
-          {% trans %}
-            Information
-          {% endtrans %}
-        </a>
-      </li>
-      {% if attachments|length > 0 %}
-        <li class="apartment__anchor-item">
-          <a href="#apartment_attachments" class="apartment__anchor-link">
-            {% include "@asuntotuotanto/misc/icon.twig" with {icon: 'floor-plan', label: ''} %}
-            {% trans %}
-              Floor plan
-            {% endtrans %}
-          </a>
-        </li>
-      {% endif %}
-      <li class="apartment__anchor-item">
-        <a href="#apartment_location" class="apartment__anchor-link">
-          {% include "@hdbt/misc/icon.twig" with {icon: 'location', label: ''} %}
-          {% trans %}
-            Location
-          {% endtrans %}
-        </a>
-      </li>
-    </ul>
-  </nav>
+	<nav class="apartment__anchor-navigation apartment__anchor-navigation--desktop wrapper wrapper--mw-1264">
+		<ul class="apartment__anchor-list">
+			<li class="apartment__anchor-item">
+				<a href="#showcase_gallery" class="apartment__anchor-link">
+					{% include "@hdbt/misc/icon.twig" with {icon: 'photo-plus', label: ''} %}
+					{% trans %}
+					Images
+					{% endtrans %}
+				</a>
+			</li>
+			<li class="apartment__anchor-item">
+				<a href="#apartment_information" class="apartment__anchor-link">
+					{% include "@hdbt/misc/icon.twig" with {icon: 'info-circle', label: ''} %}
+					{% trans %}
+					Information
+					{% endtrans %}
+				</a>
+			</li>
+			{% if attachments|length > 0 %}
+				<li class="apartment__anchor-item">
+					<a href="#apartment_attachments" class="apartment__anchor-link">
+						{% include "@asuntotuotanto/misc/icon.twig" with {icon: 'floor-plan', label: ''} %}
+						{% trans %}
+						Floor plan
+						{% endtrans %}
+					</a>
+				</li>
+			{% endif %}
+			<li class="apartment__anchor-item">
+				<a href="#apartment_location" class="apartment__anchor-link">
+					{% include "@hdbt/misc/icon.twig" with {icon: 'location', label: ''} %}
+					{% trans %}
+					Location
+					{% endtrans %}
+				</a>
+			</li>
+		</ul>
+	</nav>
 
-  <div class="apartment__content-wrapper wrapper wrapper--mw-1264">
-    <aside class="apartment__sidebar" aria-label="{{ 'Apartment sidebar information'|t }}">
-      <p class="apartment__application-information">
-        {% trans %}
-          The application period for the project starts on {{ application_start_time }} and ends on {{ application_end_time }}.
-        {% endtrans %}
-      </p>
-    </aside>
-    <div class="apartment__content">
-      <div class="apartment__type-and-address">
-        {% if ownership_type|render %}
-          <p class="apartment__ownership-type">
-            <span class="visually-hidden">({{ 'Ownership type'|t }})</span>
-            {{ ownership_type }}
-          </p>
-        {% endif %}
-        {% if district|render and address|render %}
-          <p class="apartment__address">{{ district }}, {{ address }}</p>
-        {% endif %}
-      </div>
-      {% if project_description|render %}
-        <div class="apartment__information">
-          <h2 class="apartment__information-label" id="apartment_information">
-            {% trans %}
-              Apartment information
-            {% endtrans %}
-          </h2>
-          <div class="apartment__project-description">{{ project_description|raw }}</div>
-        </div>
-      {% endif %}
-      <div class="apartment__details">
-        <h2 class="apartment__details-label">
-          {% trans %}
-            Details
-          {% endtrans %}
-        </h2>
-        <ul class="apartment__details-list">
-          {% if district|render %}
-            <li class="apartment__details-item">
-              <p>
-                <span>{% trans %}District{% endtrans %}</span>
-                <span>{{ district }}</span>
-              </p>
-            </li>
-          {% endif %}
-          {% if building_type|render %}
-            <li class="apartment__details-item">
-              <p>
-                <span>{% trans %}Building type{% endtrans %}</span>
-                <span>{{ building_type }}</span>
-              </p>
-            </li>
-          {% endif %}
-          {% if apartment_structure|render %}
-            <li class="apartment__details-item">
-              <p>
-                <span>{% trans %}Apartment structure{% endtrans %}</span>
-                <span>{{ apartment_structure }}</span>
-              </p>
-            </li>
-          {% endif %}
-          {% if living_area_size_m2|render %}
-            <li class="apartment__details-item">
-              <p>
-                <span>{% trans %}Living area size{% endtrans %} (m<sup>2</sup>)</span>
-                <span>{{ living_area_size_m2 }}</span>
-              </p>
-            </li>
-          {% endif %}
-          {% if floor|render %}
-            <li class="apartment__details-item">
-              <p>
-                <span>{% trans %}Floor{% endtrans %}</span>
-                <span>{{ floor }}</span>
-              </p>
-            </li>
-          {% endif %}
-          {% if sales_price|render %}
-            <li class="apartment__details-item">
-              <p>
-                <span>{% trans %}Sales price{% endtrans %}</span>
-                <span>{{ sales_price }}</span>
-              </p>
-            </li>
-          {% endif %}
-          {% if debt_free_sales_price|render %}
-            <li class="apartment__details-item">
-              <p>
-                <span>{% trans %}Debt free sales price{% endtrans %}</span>
-                <span>{{ debt_free_sales_price }}</span>
-              </p>
-            </li>
-          {% endif %}
-          {% if energy_class|render %}
-            <li class="apartment__details-item">
-              <p>
-                <span>{% trans %}Energy class{% endtrans %}</span>
-                <span>{{ energy_class }}</span>
-              </p>
-            </li>
-          {% endif %}
-          {% if accessibility|render %}
-            <li class="apartment__details-item">
-              <p>
-                <span>{% trans %}Accessibility{% endtrans %}</span>
-                <span>{{ accessibility }}</span>
-              </p>
-            </li>
-          {% endif %}
-          {% if site_owner|render %}
-            <li class="apartment__details-item">
-              <p>
-                <span>{% trans %}Site owner{% endtrans %}</span>
-                <span>{{ site_owner }}{{ site_renter|render ? ", #{site_renter}" : '' }}</span>
-              </p>
-            </li>
-          {% endif %}
-        </ul>
-      </div>
-      {% if attachments|length > 0 %}
-        <div class="apartment__attachments">
-          <h2 class="apartment__attachments-label" id="apartment_attachments">
-            {% trans %}
-              Attachments
-            {% endtrans %}
-          </h2>
-            <ul class="apartment__attachments-list">
-              {% for attachment in attachments %}
-                {% set description = attachment.description %}
-                {% set name = attachment.name %}
-                {% set size = attachment.size %}
-                {% set uri = attachment.uri %}
+	<div class="apartment__content-wrapper wrapper wrapper--mw-1264">
+		<aside class="apartment__sidebar" aria-label="{{ 'Apartment sidebar information'|t }}">
+			<p class="apartment__application-information">
+				{% if is_application_period_in_the_past %}
+					<p>
+						{% trans %}
+						The application period for the project ended on
+						{{ application_end_time }}.
+						{% endtrans %}
+					</p>
+				{% elseif application_start_time == null and application_end_time == null %}
+					<p>
+						{% trans %}
+							No application period specified for the project.
+						{% endtrans %}
+					</p>
+				{% else %}
+					<p>
+						{% trans %}
+						The application period for the project starts on
+						{{ application_start_time }}
+						and ends on
+						{{ application_end_time }}.
+						{% endtrans %}
+					</p>
+			{% endif %}
+			</p>
+		</aside>
+		<div class="apartment__content">
+			<div class="apartment__type-and-address">
+				{% if ownership_type|render %}
+					<p class="apartment__ownership-type">
+						<span class="visually-hidden">({{ 'Ownership type'|t }})</span>
+						{{ ownership_type }}
+					</p>
+				{% endif %}
+				{% if district|render and address|render %}
+					<p class="apartment__address">{{ district }},
+						{{ address }}</p>
+				{% endif %}
+			</div>
+			{% if project_description|render %}
+				<div class="apartment__information">
+					<h2 class="apartment__information-label" id="apartment_information">
+						{% trans %}
+						Apartment information
+						{% endtrans %}
+					</h2>
+					<div class="apartment__project-description">{{ project_description|raw }}</div>
+				</div>
+			{% endif %}
+			<div class="apartment__details">
+				<h2 class="apartment__details-label">
+					{% 
+						if (living_area_size_m2|render == '0,0' or living_area_size_m2|render == null)
+						and (floor|render <= '0')
+						and (sales_price|render == '0,00€' or sales_price|render == '')
+						and (debt_free_sales_price|render == '0,00€' or debt_free_sales_price|render == '')
+						and (apartment_number|render == '')
+						and (apartment_structure|render == '')
+					%}
+					{% else %}
+						{% trans %}
+							Details
+						{% endtrans %}
+					{% endif %}
+				</h2>
+				<ul class="apartment__details-list">
+					{% if district|render %}
+						<li class="apartment__details-item">
+							<p>
+								<span>{% trans %}District{% endtrans %}</span>
+								<span>{{ district }}</span>
+							</p>
+						</li>
+					{% endif %}
+					{% if building_type|render %}
+						<li class="apartment__details-item">
+							<p>
+								<span>{% trans %}Building type{% endtrans %}</span>
+								<span>{{ building_type }}</span>
+							</p>
+						</li>
+					{% endif %}
+					{% if apartment_structure|render %}
+						<li class="apartment__details-item">
+							<p>
+								<span>{% trans %}Apartment structure{% endtrans %}</span>
+								<span>{{ apartment_structure }}</span>
+							</p>
+						</li>
+					{% endif %}
+					{% if living_area_size_m2|render and living_area_size_m2|render != '0,0' and living_area_size_m2|render != null %}
+						<li class="apartment__details-item">
+							<p>
+								<span>{% trans %}Living area size{% endtrans %}
+									(m<sup>2</sup>)</span>
+								<span>{{ living_area_size_m2 }}</span>
+							</p>
+						</li>
+					{% endif %}
+					{% if floor|render and floor|render > '0' %}
+						<li class="apartment__details-item">
+							<p>
+								<span>{% trans %}Floor{% endtrans %}</span>
+								<span>{{ floor }}</span>
+							</p>
+						</li>
+					{% endif %}
+					{% if sales_price|render and sales_price|render != '0,00€' %}
+						<li class="apartment__details-item">
+							<p>
+								<span>{% trans %}Sales price{% endtrans %}</span>
+								<span>{{ sales_price }}</span>
+							</p>
+						</li>
+					{% endif %}
+					{% if debt_free_sales_price|render and debt_free_sales_price|render != '0,00€' %}
+						<li class="apartment__details-item">
+							<p>
+								<span>{% trans %}Debt free sales price{% endtrans %}</span>
+								<span>{{ debt_free_sales_price }}</span>
+							</p>
+						</li>
+					{% endif %}
+					{% if energy_class|render %}
+						<li class="apartment__details-item">
+							<p>
+								<span>{% trans %}Energy class{% endtrans %}</span>
+								<span>{{ energy_class }}</span>
+							</p>
+						</li>
+					{% endif %}
+					{% if accessibility|render %}
+						<li class="apartment__details-item">
+							<p>
+								<span>{% trans %}Accessibility{% endtrans %}</span>
+								<span>{{ accessibility }}</span>
+							</p>
+						</li>
+					{% endif %}
+					{% if site_owner|render %}
+						<li class="apartment__details-item">
+							<p>
+								<span>{% trans %}Site owner{% endtrans %}</span>
+								<span>{{ site_owner }}{{ site_renter|render ? ", #{site_renter}" : '' }}</span>
+							</p>
+						</li>
+					{% endif %}
+				</ul>
+			</div>
+			{% if attachments|length > 0 %}
+				<div class="apartment__attachments">
+					<h2 class="apartment__attachments-label" id="apartment_attachments">
+						{% trans %}
+						Attachments
+						{% endtrans %}
+					</h2>
+					<ul class="apartment__attachments-list">
+						{% for attachment in attachments %}
+							{% set description = attachment.description %}
+							{% set name = attachment.name %}
+							{% set size = attachment.size %}
+							{% set uri = attachment.uri %}
 
-                <li class="apartment__attachment-item">
-                  <a href="{{ uri }}" download="{{ description ?: name }}" class="apartment__attachment-link">
-                    {% include "@hdbt/misc/icon.twig" with {icon: 'document', label: ''} %}
-                    <div class="apartment__attachment-content">
-                      <p class="apartment__attachment-description">{{ 'Download'|t }}</p>
-                      <p class="apartment__attachment-name">
-                        <span class="visually-hidden">({{ 'File name'|t }})</span>
-                        {{ description ?: name }}
-                      </p>
-                      <p class="apartment__attachment-size">
-                        <span class="visually-hidden">({{ 'File size'|t }})</span>
-                        {{ size }}
-                      </p>
-                    </div>
-                  </a>
-                </li>
-              {% endfor %}
-            </ul>
-        </div>
-      {% endif %}
-    </div>
-  </div>
+							<li class="apartment__attachment-item">
+								<a href="{{ uri }}" download="{{ description ?: name }}" class="apartment__attachment-link">
+									{% include "@hdbt/misc/icon.twig" with {icon: 'document', label: ''} %}
+									<div class="apartment__attachment-content">
+										<p class="apartment__attachment-description">{{ 'Download'|t }}</p>
+										<p class="apartment__attachment-name">
+											<span class="visually-hidden">({{ 'File name'|t }})</span>
+											{{ description ?: name }}
+										</p>
+										<p class="apartment__attachment-size">
+											<span class="visually-hidden">({{ 'File size'|t }})</span>
+											{{ size }}
+										</p>
+									</div>
+								</a>
+							</li>
+						{% endfor %}
+					</ul>
+				</div>
+			{% endif %}
+		</div>
+	</div>
 
-  <div class="apartment__area-overview-wrapper wrapper wrapper--mw-1264" id="apartment_location">
-    <div class="apartment__area-overview">
-      <h2 class="apartment__area-overview-label">
-        {% trans %}
-          Area overview
-        {% endtrans %}
-      </h2>
-      {% if services|length > 0 %}
-        <ul class="apartment__services-list">
-          {% for service in services %}
-            <li class="apartment__service-item">
-              {% include "@hdbt/misc/icon.twig" with {icon: 'location', label: ''} %}
-              <p>{{ service.name }} {{ service.distance }} m</p>
-            </li>
-          {% endfor %}
-        </ul>
-      {% endif %}
-      {% if project_area_description|render %}
-        <div class="apartment__project-area-description">
-          {% include "@hdbt/misc/icon.twig" with {icon: 'location', label: ''} %}
-          <p>{{ project_area_description }}</p>
-        </div>
-      {% endif %}
-      {% if services_url %}
-        <a class="apartment__area-overvink-link" href="{{ services_url.uri }}">{{ services_url.title }}</a>
-      {% endif %}
-    </div>
-    {% if city|render and street_name|render and street_number|render %}
-      <div class="apartment__map-location">
-        <h2 class="apartment__map-location-label">
-          {% trans %}
-            Location
-          {% endtrans %}
-        </h2>
-        <div>
+	{% if services|length > 0 and project_area_description|render and services_url %}
+		<div class="apartment__area-overview-wrapper wrapper wrapper--mw-1264" id="apartment_location">
+			<div class="apartment__area-overview">
+				<h2 class="apartment__area-overview-label">
+					{% trans %}
+					Area overview
+					{% endtrans %}
+				</h2>
+				{% if services|length > 0 %}
+					<ul class="apartment__services-list">
+						{% for service in services %}
+							<li class="apartment__service-item">
+								{% include "@hdbt/misc/icon.twig" with {icon: 'location', label: ''} %}
+								<p>{{ service.name }}
+									{{ service.distance }}
+									m</p>
+							</li>
+						{% endfor %}
+					</ul>
+				{% endif %}
+				{% if project_area_description|render %}
+					<div class="apartment__project-area-description">
+						{% include "@hdbt/misc/icon.twig" with {icon: 'location', label: ''} %}
+						<p>{{ project_area_description }}</p>
+					</div>
+				{% endif %}
+				{% if services_url %}
+					<a class="apartment__area-overvink-link" href="{{ services_url.uri }}">{{ services_url.title }}</a>
+				{% endif %}
+			</div>
+			{% if city|render and street_name|render and street_number|render %}
+				<div class="apartment__map-location">
+					<h2 class="apartment__map-location-label">
+						{% trans %}
+						Location
+						{% endtrans %}
+					</h2>
+					<div>
 
-          {% set embed_url_base = "https://palvelukartta.hel.fi/fi/embed" %}
+						{% set embed_url_base = "https://palvelukartta.hel.fi/fi/embed" %}
 
-          {% if coordinate_lat|render and coordinate_lon|render %}
-            {% set embed_url_suffix = "/?lat=" ~ coordinate_lat ~ "&lon=" ~ coordinate_lon %}
-          {% else %}
-            {% set embed_url_parameters = city|lower ~ '/' ~ street_name ~ '/' ~ street_number %}
-            {% set embed_url_suffix = "/address/" ~ embed_url_parameters %}
-          {% endif %}
+						{% if coordinate_lat|render and coordinate_lon|render %}
+							{% set embed_url_suffix = "/?lat=" ~ coordinate_lat ~ "&lon=" ~ coordinate_lon %}
+						{% else %}
+							{% set embed_url_parameters = city|lower ~ '/' ~ street_name ~ '/' ~ street_number %}
+							{% set embed_url_suffix = "/address/" ~ embed_url_parameters %}
+						{% endif %}
 
-          {% set embed_link = embed_url_base ~ embed_url_suffix ~ "&city=helsinki,espoo,vantaa,kauniainen,kirkkonummi" %}
+						{% set embed_link = embed_url_base ~ embed_url_suffix ~ "&city=helsinki,espoo,vantaa,kauniainen,kirkkonummi" %}
 
-          <iframe
-            title="{{ 'Map location of the @apartment apartment'|t({'@apartment': label[0]['#context']['value'] }) }}"
-            style="position: absolute; top: 0; left: 0; border: none; width: 100%; height: 100%;"
-            src="{{ embed_link }}"></iframe>
+						<iframe title="{{ 'Map location of the @apartment apartment'|t({'@apartment': label[0]['#context']['value'] }) }}" style="position: absolute; top: 0; left: 0; border: none; width: 100%; height: 100%;" src="{{ embed_link }}"></iframe>
 
-        </div>
-      </div>
-    {% endif %}
-  </div>
+					</div>
+				</div>
+			{% endif %}
+		</div>
+	{% endif %}
 
-  {% if is_application_period_active %}
-    <div class="apartment__cta">
-      <div class="apartment__cta-image">
-        {% if not cta_image|render %}
-          <div class="apartment__cta-image--missing"></div>
-        {% endif %}
-        {% if cta_image|render %}
-          {{ cta_image }}
-        {% endif %}
-      </div>
-      <div class="apartment__cta-content-wrapper">
-        <div class="apartment__cta-content">
-          <h2>
-            {% trans %}
-              Could this be your home?
-            {% endtrans %}
-          </h2>
-          {% include '@asuntotuotanto/button/button.html.twig' with {
-            type: 'secondary',
-            disabled: false,
-            label: 'Create an application'|t,
-            href: application_url,
-            icon_last: true,
-            icon_last_type: 'arrow-right'
-            }
-          %}
-        </div>
-      </div>
-    </div>
-  {% endif %}
+	{% if is_application_period_active %}
+		<div class="apartment__cta">
+			<div class="apartment__cta-image">
+				{% if not cta_image|render %}
+					<div class="apartment__cta-image--missing"></div>
+				{% endif %}
+				{% if cta_image|render %}
+					{{ cta_image }}
+				{% endif %}
+			</div>
+			<div class="apartment__cta-content-wrapper">
+				<div class="apartment__cta-content">
+					<h2>
+						{% trans %}
+						Could this be your home?
+						{% endtrans %}
+					</h2>
+					{% include '@asuntotuotanto/button/button.html.twig' with {
+							type: 'secondary',
+							disabled: false,
+							label: 'Create an application'|t,
+							href: application_url,
+							icon_last: true,
+							icon_last_type: 'arrow-right'
+						}
+          			%}
+				</div>
+			</div>
+		</div>
+	{% endif %}
 </article>

--- a/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
@@ -94,7 +94,7 @@
 {% set apartment_number = content.field_apartment_number.0 %}
 
 <article{{attributes.addClass(classes)}}>
-	<div class="sticky-navigation is-hidden" aria-hidden="true" id="sticky_navigation">
+  <div class="sticky-navigation is-hidden" aria-hidden="true" id="sticky_navigation">
 		<div class="sticky-navigation__container wrapper wrapper--mw-1264">
 			<div class="sticky-navigation__content">
 				<div class="sticky-navigation__content-section">
@@ -236,7 +236,7 @@
 				<a href="#showcase_gallery" class="apartment__anchor-link">
 					{% include "@hdbt/misc/icon.twig" with {icon: 'photo-plus', label: ''} %}
 					{% trans %}
-					Images
+					  Images
 					{% endtrans %}
 				</a>
 			</li>
@@ -244,7 +244,7 @@
 				<a href="#apartment_information" class="apartment__anchor-link">
 					{% include "@hdbt/misc/icon.twig" with {icon: 'info-circle', label: ''} %}
 					{% trans %}
-					Information
+					  Information
 					{% endtrans %}
 				</a>
 			</li>
@@ -253,7 +253,7 @@
 					<a href="#apartment_attachments" class="apartment__anchor-link">
 						{% include "@asuntotuotanto/misc/icon.twig" with {icon: 'floor-plan', label: ''} %}
 						{% trans %}
-						Floor plan
+						  Floor plan
 						{% endtrans %}
 					</a>
 				</li>
@@ -262,7 +262,7 @@
 				<a href="#apartment_location" class="apartment__anchor-link">
 					{% include "@hdbt/misc/icon.twig" with {icon: 'location', label: ''} %}
 					{% trans %}
-					Location
+					  Location
 					{% endtrans %}
 				</a>
 			</li>
@@ -308,7 +308,7 @@
 				<div class="apartment__information">
 					<h2 class="apartment__information-label" id="apartment_information">
 						{% trans %}
-						Apartment information
+						  Apartment information
 						{% endtrans %}
 					</h2>
 					<div class="apartment__project-description">{{ project_description|raw }}</div>
@@ -416,7 +416,7 @@
 				<div class="apartment__attachments">
 					<h2 class="apartment__attachments-label" id="apartment_attachments">
 						{% trans %}
-						Attachments
+						  Attachments
 						{% endtrans %}
 					</h2>
 					<ul class="apartment__attachments-list">
@@ -454,7 +454,7 @@
 			<div class="apartment__area-overview">
 				<h2 class="apartment__area-overview-label">
 					{% trans %}
-					Area overview
+					  Area overview
 					{% endtrans %}
 				</h2>
 				{% if services|length > 0 %}
@@ -483,24 +483,22 @@
 				<div class="apartment__map-location">
 					<h2 class="apartment__map-location-label">
 						{% trans %}
-						Location
+						  Location
 						{% endtrans %}
 					</h2>
-					<div>
+          <div>
+            {% set embed_url_base = "https://palvelukartta.hel.fi/fi/embed" %}
 
-						{% set embed_url_base = "https://palvelukartta.hel.fi/fi/embed" %}
+            {% if coordinate_lat|render and coordinate_lon|render %}
+              {% set embed_url_suffix = "/?lat=" ~ coordinate_lat ~ "&lon=" ~ coordinate_lon %}
+            {% else %}
+              {% set embed_url_parameters = city|lower ~ '/' ~ street_name ~ '/' ~ street_number %}
+              {% set embed_url_suffix = "/address/" ~ embed_url_parameters %}
+            {% endif %}
 
-						{% if coordinate_lat|render and coordinate_lon|render %}
-							{% set embed_url_suffix = "/?lat=" ~ coordinate_lat ~ "&lon=" ~ coordinate_lon %}
-						{% else %}
-							{% set embed_url_parameters = city|lower ~ '/' ~ street_name ~ '/' ~ street_number %}
-							{% set embed_url_suffix = "/address/" ~ embed_url_parameters %}
-						{% endif %}
+            {% set embed_link = embed_url_base ~ embed_url_suffix ~ "&city=helsinki,espoo,vantaa,kauniainen,kirkkonummi" %}
 
-						{% set embed_link = embed_url_base ~ embed_url_suffix ~ "&city=helsinki,espoo,vantaa,kauniainen,kirkkonummi" %}
-
-						<iframe title="{{ 'Map location of the @apartment apartment'|t({'@apartment': label[0]['#context']['value'] }) }}" style="position: absolute; top: 0; left: 0; border: none; width: 100%; height: 100%;" src="{{ embed_link }}"></iframe>
-
+            <iframe title="{{ 'Map location of the @apartment apartment'|t({'@apartment': label[0]['#context']['value'] }) }}" style="position: absolute; top: 0; left: 0; border: none; width: 100%; height: 100%;" src="{{ embed_link }}"></iframe>
 					</div>
 				</div>
 			{% endif %}
@@ -521,7 +519,7 @@
 				<div class="apartment__cta-content">
 					<h2>
 						{% trans %}
-						Could this be your home?
+						  Could this be your home?
 						{% endtrans %}
 					</h2>
 					{% include '@asuntotuotanto/button/button.html.twig' with {
@@ -532,7 +530,7 @@
 							icon_last: true,
 							icon_last_type: 'arrow-right'
 						}
-          			%}
+          %}
 				</div>
 			</div>
 		</div>

--- a/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
@@ -103,8 +103,8 @@
 						{% if apartment_structure|render %}
 							<span>{{ apartment_structure }}</span>
 						{% endif %}
-						<span aria-hidden="true"></span>
-						{% if living_area_size_m2|render %}
+						{% if living_area_size_m2|render and living_area_size_m2|render != '0,0' %}
+              <span aria-hidden="true"></span>
 							<span>{{ living_area_size_m2 }}
 								m<sup>2</sup>
 							</span>
@@ -194,28 +194,30 @@
 					label: 'Create an application'|t,
 					href: application_url
 					}
-        		%}
-			{% elseif is_application_period_in_the_past %}
-				<p>
-					{% trans %}
-						The application period for the project ended on
-						{{ application_end_time }}.
-					{% endtrans %}
-				</p>
-			{% elseif application_start_time == null and application_end_time == null %}
-				{% trans %}
-					No application period specified for the project.
-				{% endtrans %}
-			{% else %}
-				<p>
-					{% trans %}
-						The application period for the project starts on
-						{{ application_start_time }}
-						and ends on
-						{{ application_end_time }}.
-					{% endtrans %}
-				</p>
-			{% endif %}
+        %}
+      {% elseif is_application_period_in_the_past %}
+        <p class="apartment__application-information">
+          {% trans %}
+            The application period for the project ended on
+            {{ application_end_time }}.
+          {% endtrans %}
+        </p>
+      {% elseif application_start_time == null and application_end_time == null %}
+        <p class="apartment__application-information">
+          {% trans %}
+            No application period specified for the project.
+          {% endtrans %}
+        </p>
+      {% else %}
+        <p class="apartment__application-information">
+          {% trans %}
+            The application period for the project starts on
+            {{ application_start_time }}
+            and ends on
+            {{ application_end_time }}.
+          {% endtrans %}
+        </p>
+      {% endif %}
 		</div>
 	</div>
 
@@ -271,28 +273,22 @@
 		<aside class="apartment__sidebar" aria-label="{{ 'Apartment sidebar information'|t }}">
 			<p class="apartment__application-information">
 				{% if is_application_period_in_the_past %}
-					<p>
-						{% trans %}
-						The application period for the project ended on
-						{{ application_end_time }}.
-						{% endtrans %}
-					</p>
+          {% trans %}
+            The application period for the project ended on
+            {{ application_end_time }}.
+          {% endtrans %}
 				{% elseif application_start_time == null and application_end_time == null %}
-					<p>
-						{% trans %}
-							No application period specified for the project.
-						{% endtrans %}
-					</p>
+          {% trans %}
+            No application period specified for the project.
+          {% endtrans %}
 				{% else %}
-					<p>
-						{% trans %}
-						The application period for the project starts on
-						{{ application_start_time }}
-						and ends on
-						{{ application_end_time }}.
-						{% endtrans %}
-					</p>
-			{% endif %}
+          {% trans %}
+            The application period for the project starts on
+            {{ application_start_time }}
+            and ends on
+            {{ application_end_time }}.
+          {% endtrans %}
+			  {% endif %}
 			</p>
 		</aside>
 		<div class="apartment__content">
@@ -320,14 +316,12 @@
 			{% endif %}
 			<div class="apartment__details">
 				<h2 class="apartment__details-label">
-					{% 
-						if (living_area_size_m2|render == '0,0' or living_area_size_m2|render == null)
-						and (floor|render <= '0')
-						and (sales_price|render == '0,00€' or sales_price|render == '')
-						and (debt_free_sales_price|render == '0,00€' or debt_free_sales_price|render == '')
-						and (apartment_number|render == '')
-						and (apartment_structure|render == '')
-					%}
+					{% if (living_area_size_m2|render == '0,0' or living_area_size_m2|render == null)
+              and (floor|render <= '0')
+              and (sales_price|render == '0,00€' or sales_price|render == '')
+              and (debt_free_sales_price|render == '0,00€' or debt_free_sales_price|render == '')
+              and (apartment_number|render == '')
+              and (apartment_structure|render == '') %}
 					{% else %}
 						{% trans %}
 							Details

--- a/public/themes/custom/asuntotuotanto/templates/content/node--project--full.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/content/node--project--full.html.twig
@@ -173,7 +173,7 @@
       <div class="project__images--missing"></div>
     {% endif %}
     {% if images|render %}
-        {{ images }}
+      {{ images }}
     {% endif %}
   </div>
 
@@ -365,31 +365,31 @@
               Attachments
             {% endtrans %}
           </h2>
-            <ul class="project__attachments-list">
-              {% for attachment in attachments %}
-                {% set description = attachment.description %}
-                {% set name = attachment.name %}
-                {% set size = attachment.size %}
-                {% set uri = attachment.uri %}
+          <ul class="project__attachments-list">
+            {% for attachment in attachments %}
+              {% set description = attachment.description %}
+              {% set name = attachment.name %}
+              {% set size = attachment.size %}
+              {% set uri = attachment.uri %}
 
-                <li class="project__attachment-item">
-                  <a href="{{ uri }}" download="{{ description ?: name }}" class="project__attachment-link">
-                    {% include "@hdbt/misc/icon.twig" with {icon: 'document', label: ''} %}
-                    <div class="project__attachment-content">
-                      <p class="project__attachment-description">{{ 'Download'|t }}</p>
-                      <p class="project__attachment-name">
-                        <span class="visually-hidden">({{ 'File name'|t }})</span>
-                        {{ description ?: name }}
-                      </p>
-                      <p class="project__attachment-size">
-                        <span class="visually-hidden">({{ 'File size'|t }})</span>
-                        {{ size }}
-                      </p>
-                    </div>
-                  </a>
-                </li>
-              {% endfor %}
-            </ul>
+              <li class="project__attachment-item">
+                <a href="{{ uri }}" download="{{ description ?: name }}" class="project__attachment-link">
+                  {% include "@hdbt/misc/icon.twig" with {icon: 'document', label: ''} %}
+                  <div class="project__attachment-content">
+                    <p class="project__attachment-description">{{ 'Download'|t }}</p>
+                    <p class="project__attachment-name">
+                      <span class="visually-hidden">({{ 'File name'|t }})</span>
+                      {{ description ?: name }}
+                    </p>
+                    <p class="project__attachment-size">
+                      <span class="visually-hidden">({{ 'File size'|t }})</span>
+                      {{ size }}
+                    </p>
+                  </div>
+                </a>
+              </li>
+            {% endfor %}
+          </ul>
         </div>
       {% endif %}
     </div>
@@ -430,7 +430,6 @@
           {% endtrans %}
         </h2>
         <div>
-
           {% set embed_url_base = "https://palvelukartta.hel.fi/fi/embed" %}
 
           {% if coordinate_lat|render and coordinate_lon|render %}
@@ -445,8 +444,8 @@
           <iframe
             title="{{ 'Map location of the @project project'|t({'@project': label[0]['#context']['value'] }) }}"
             style="position: absolute; top: 0; left: 0; border: none; width: 100%; height: 100%;"
-            src="{{ embed_link }}"></iframe>
-
+            src="{{ embed_link }}">
+          </iframe>
         </div>
       </div>
     {% endif %}

--- a/public/themes/custom/asuntotuotanto/templates/content/node--project--full.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/content/node--project--full.html.twig
@@ -217,14 +217,22 @@
   <div class="project__content-wrapper wrapper wrapper--mw-1264">
     <aside class="project__sidebar" aria-label="{{ 'Project sidebar information'|t }}">
       <p class="project__apartment-count-information">
-        {% trans %}
-          {{ apartments_count }} apartments
-        {% endtrans %}
+        {% if apartments_count  > 0  %}
+          {% trans %}
+            {{ apartments_count }} apartments
+          {% endtrans %}
+        {% endif %}
       </p>
       <p class="project__application-information">
-        {% trans %}
-          The application period for the destination starts on {{ application_start_time }} and ends on {{ application_end_time }}.
-        {% endtrans %}
+        {% if application_start_time  == null and application_end_time == null  %}
+          {% trans %}
+            No application specified for the project.
+          {% endtrans %}
+        {% else %}
+          {% trans %}
+            The application period for the destination starts on {{ application_start_time }} and ends on {{ application_end_time }}.
+          {% endtrans %}
+        {% endif %}
       </p>
     </aside>
     <div class="project__content">
@@ -251,12 +259,24 @@
       {% endif %}
       <div class="project__details">
         <h2 class="project__details-label">
-          {% trans %}
-            Details
-          {% endtrans %}
+          {% if (district|render == null or district|render == '')
+              and (building_type|render == null or building_type|render == '')
+              and (apartment_structures|render == null or apartment_structures|render == '')
+              and (apartment_living_area_sizes_m2|render == '0,0 - 0,0' or apartment_living_area_sizes_m2|render == null)
+              and (apartment_sales_prices|render == '0,00 € - 0,00 €' or apartment_sales_prices|render == null)
+              and (apartment_debt_free_sales_prices|render == '0,00 € - 0,00 €' or apartment_debt_free_sales_prices|render == null)
+              and (apartment_prices|render == null)
+              and (energy_class|render == null)
+              and (accessibility|render == null)
+              and (site_owner|render == null) %}
+          {% else %}
+						{% trans %}
+							Details
+						{% endtrans %}
+					{% endif %}
         </h2>
         <ul class="project__details-list">
-          {% if district|render %}
+          {% if district|render and district|render != null and district|render != '' %}
             <li class="project__details-item">
               <p>
                 <span>{% trans %}District{% endtrans %}</span>
@@ -264,7 +284,7 @@
               </p>
             </li>
           {% endif %}
-          {% if building_type|render %}
+          {% if building_type|render and building_type|render != null and building_type|render != '' %}
             <li class="project__details-item">
               <p>
                 <span>{% trans %}Building type{% endtrans %}</span>
@@ -272,7 +292,7 @@
               </p>
             </li>
           {% endif %}
-          {% if apartment_structures|render %}
+          {% if apartment_structures|render and apartment_structures|render != null and apartment_structures|render != '' %}
             <li class="project__details-item">
               <p>
                 <span>{% trans %}Apartment stuctures{% endtrans %}</span>
@@ -280,7 +300,7 @@
               </p>
             </li>
           {% endif %}
-          {% if apartment_living_area_sizes_m2|render %}
+          {% if apartment_living_area_sizes_m2|render and apartment_living_area_sizes_m2|render != '0,0 - 0,0' and apartment_living_area_sizes_m2|render != null %}
             <li class="project__details-item">
               <p>
                 <span>{% trans %}Living area sizes{% endtrans %} (m<sup>2</sup>)</span>
@@ -288,7 +308,7 @@
               </p>
             </li>
           {% endif %}
-          {% if project_type != "HASO" and apartment_sales_prices|render %}
+          {% if project_type != "HASO" and apartment_sales_prices|render and apartment_sales_prices|render != null and apartment_sales_prices|render != '0,00 € - 0,00 €' %}
             <li class="project__details-item">
               <p>
                 <span>{% trans %}Sales price{% endtrans %}</span>
@@ -296,7 +316,7 @@
               </p>
             </li>
           {% endif %}
-          {% if project_type != "HASO" and apartment_debt_free_sales_prices|render %}
+          {% if project_type != "HASO" and apartment_debt_free_sales_prices|render and apartment_debt_free_sales_prices|render != null and apartment_debt_free_sales_prices|render != '0,00 € - 0,00 €' %}
             <li class="project__details-item">
               <p>
                 <span>{% trans %}Debt free sales price{% endtrans %}</span>
@@ -304,7 +324,7 @@
               </p>
             </li>
           {% endif %}
-          {% if project_type == "HASO" and apartment_prices|render %}
+          {% if project_type == "HASO" and apartment_prices|render and apartment_prices|render != null %}
             <li class="project__details-item">
               <p>
                 <span>{% trans %}Right of occupancy payment{% endtrans %}</span>
@@ -312,7 +332,7 @@
               </p>
             </li>
           {% endif %}
-          {% if energy_class|render %}
+          {% if energy_class|render and energy_class|render != null %}
             <li class="project__details-item">
               <p>
                 <span>{% trans %}Energy class{% endtrans %}</span>
@@ -320,7 +340,7 @@
               </p>
             </li>
           {% endif %}
-          {% if accessibility|render %}
+          {% if accessibility|render and accessibility|render != null %}
             <li class="project__details-item">
               <p>
                 <span>{% trans %}Accessibility{% endtrans %}</span>
@@ -328,7 +348,7 @@
               </p>
             </li>
           {% endif %}
-          {% if site_owner|render %}
+          {% if site_owner|render and site_owner|render != null %}
             <li class="project__details-item">
               <p>
                 <span>{% trans %}Site owner{% endtrans %}</span>

--- a/public/themes/custom/asuntotuotanto/templates/views/project/views-view--project-apartments-listing.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/views/project/views-view--project-apartments-listing.html.twig
@@ -36,6 +36,7 @@
     'project-apartments-listing'
   ]
 %}
+
 <div{{ attributes.addClass(classes) }}>
   {{ title_prefix }}
   {{ title }}
@@ -50,29 +51,31 @@
   {{ exposed }}
   {{ attachment_before }}
 
-  <div class="project-apartments-listing__header wrapper wrapper--mw-1264">
-    <h2>
-      {% trans %}
-        Project apartments
-      {% endtrans %}
-    </h2>
-    <h3>
-      {% trans %}
-        In total {{ apartments_count }} apartment
-      {% plural apartments_count %}
-        In total {{ apartments_count }} apartments
-      {% endtrans %}
-    </h3>
-  </div>
+  {% if rows %}
+    <div class="project-apartments-listing__header wrapper wrapper--mw-1264">
+      <h2>
+        {% trans %}
+          Project apartments
+        {% endtrans %}
+      </h2>
+      <h3>
+        {% trans %}
+          In total {{ apartments_count }} apartment
+        {% plural apartments_count %}
+          In total {{ apartments_count }} apartments
+        {% endtrans %}
+      </h3>
+    </div>
 
-  <div class="project-apartments-listing__content">
-    {% if rows -%}
-      {{ rows }}
-    {% elseif empty -%}
-      {{ empty }}
-    {% endif %}
-    {{ pager }}
-  </div>
+    <div class="project-apartments-listing__content">
+      {% if rows -%}
+        {{ rows }}
+      {% elseif empty -%}
+        {{ empty }}
+      {% endif %}
+      {{ pager }}
+    </div>
+  {% endif %}
 
   {{ attachment_after }}
   {{ more }}


### PR DESCRIPTION
All fields (including title) that are empty under Apartment's "Details" are now hidden. Also, logic for some other fields that might be empty, were updated (i.e., mainly different text shows up if those fields are empty). 