### PR TITLE
ASU-1060: Update logic for empty fields and apartments count.

### DIFF
--- a/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
@@ -299,8 +299,8 @@
               and (floor|render <= '0')
               and (sales_price|render == '0,00€' or sales_price|render == '')
               and (debt_free_sales_price|render == '0,00€' or debt_free_sales_price|render == '')
-              and (apartment_number|render == '')
-              and (apartment_structure|render == '') %}
+              and (apartment_structure|render == '')
+          %}
 					{% else %}
 						{% trans %}
 							Details

--- a/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
@@ -195,20 +195,8 @@
 					href: application_url
 					}
         %}
-      {% elseif is_application_period_in_the_past %}
-        <p class="apartment__application-information">
-          {% trans %}
-            The application period for the project ended on
-            {{ application_end_time }}.
-          {% endtrans %}
-        </p>
-      {% elseif application_start_time == null and application_end_time == null %}
-        <p class="apartment__application-information">
-          {% trans %}
-            No application period specified for the project.
-          {% endtrans %}
-        </p>
-      {% else %}
+      {% endif %}
+      {% if (is_application_period_in_the_past is same as(false)) and (application_start_time != null and application_end_time != null) %}
         <p class="apartment__application-information">
           {% trans %}
             The application period for the project starts on
@@ -272,16 +260,7 @@
 	<div class="apartment__content-wrapper wrapper wrapper--mw-1264">
 		<aside class="apartment__sidebar" aria-label="{{ 'Apartment sidebar information'|t }}">
 			<p class="apartment__application-information">
-				{% if is_application_period_in_the_past %}
-          {% trans %}
-            The application period for the project ended on
-            {{ application_end_time }}.
-          {% endtrans %}
-				{% elseif application_start_time == null and application_end_time == null %}
-          {% trans %}
-            No application period specified for the project.
-          {% endtrans %}
-				{% else %}
+        {% if (is_application_period_in_the_past is same as(false)) and (application_start_time != null and application_end_time != null) %}
           {% trans %}
             The application period for the project starts on
             {{ application_start_time }}

--- a/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
@@ -299,7 +299,9 @@
               and (floor|render <= '0')
               and (sales_price|render == '0,00€' or sales_price|render == '')
               and (debt_free_sales_price|render == '0,00€' or debt_free_sales_price|render == '')
-              and (apartment_structure|render == '')
+              and (energy_class|render == null)
+              and (accessibility|render == null)
+              and (site_owner|render == null)
           %}
 					{% else %}
 						{% trans %}

--- a/public/themes/custom/asuntotuotanto/templates/content/node--project--full.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/content/node--project--full.html.twig
@@ -217,18 +217,25 @@
   <div class="project__content-wrapper wrapper wrapper--mw-1264">
     <aside class="project__sidebar" aria-label="{{ 'Project sidebar information'|t }}">
       <p class="project__apartment-count-information">
-        {% if apartments_count > 2 %}
+        {% if apartments_count >= 2 %}
           {% trans %}
             {{ apartments_count }} apartments
           {% endtrans %}
         {% endif %}
       </p>
       <p class="project__application-information">
+        {#
         {% if application_start_time == null and application_end_time == null  %}
           {% trans %}
             Application period has not been specified.
           {% endtrans %}
         {% else %}
+          {% trans %}
+            The application period for this project starts on {{ application_start_time }} and ends on {{ application_end_time }}.
+          {% endtrans %}
+        {% endif %}
+        #}
+        {% if application_start_time != null and application_end_time != null  %}
           {% trans %}
             The application period for this project starts on {{ application_start_time }} and ends on {{ application_end_time }}.
           {% endtrans %}

--- a/public/themes/custom/asuntotuotanto/templates/content/node--project--full.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/content/node--project--full.html.twig
@@ -275,7 +275,8 @@
               and (apartment_prices|render == null)
               and (energy_class|render == null)
               and (accessibility|render == null)
-              and (site_owner|render == null) %}
+              and (site_owner|render == null)
+          %}
           {% else %}
 						{% trans %}
 							Details


### PR DESCRIPTION
On project page:
- updated apartments count to: >= 2
- application start and end time are shown only if they are set

On apartment page:
- application start and end time are shown only if they are set & are not expired (i.e. in the past)