### PR TITLE
ASU-1046: Update apartment template with newly created fields (and logic)

### DIFF
--- a/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
@@ -92,6 +92,10 @@
 {% set sales_price = content.field_sales_price.0 %}
 {% set debt_free_sales_price = content.field_debt_free_sales_price.0 %}
 {% set apartment_number = content.field_apartment_number.0 %}
+{% set financing_fee = content.field_financing_fee.0 %}
+{% set maintenance_fee = content.field_maintenance_fee.0 %}
+{% set right_of_occupancy_fee = content.field_right_of_occupancy_fee.0 %}
+{% set right_of_occupancy_payment = content.field_right_of_occupancy_payment.0 %}
 
 <article{{attributes.addClass(classes)}}>
   <div class="sticky-navigation is-hidden" aria-hidden="true" id="sticky_navigation">
@@ -318,10 +322,14 @@
 				<h2 class="apartment__details-label">
 					{% if (living_area_size_m2|render == '0,0' or living_area_size_m2|render == null)
               and (floor|render <= '0')
-              and (sales_price|render == '0,00€' or sales_price|render == '')
-              and (debt_free_sales_price|render == '0,00€' or debt_free_sales_price|render == '')
+              and (sales_price|render == '0,00€' or sales_price|render == null)
+              and (debt_free_sales_price|render == '0,00€' or debt_free_sales_price|render == null)
               and (apartment_number|render == '')
-              and (apartment_structure|render == '') %}
+              and (apartment_structure|render == '')
+              and (right_of_occupancy_fee|render == '0.00€')
+              and (maintenance_fee|render == '0.00€ / kk')
+              and (financing_fee|render == '0.00€ / month')
+          %}
 					{% else %}
 						{% trans %}
 							Details
@@ -370,7 +378,7 @@
 							</p>
 						</li>
 					{% endif %}
-					{% if sales_price|render and sales_price|render != '0,00€' %}
+					{% if sales_price|render and sales_price|render != '0,00€' and sales_price|render != null %}
 						<li class="apartment__details-item">
 							<p>
 								<span>{% trans %}Sales price{% endtrans %}</span>
@@ -378,11 +386,53 @@
 							</p>
 						</li>
 					{% endif %}
-					{% if debt_free_sales_price|render and debt_free_sales_price|render != '0,00€' %}
+					{% if debt_free_sales_price|render and debt_free_sales_price|render != '0,00€' and debt_free_sales_price|render != null %}
 						<li class="apartment__details-item">
 							<p>
 								<span>{% trans %}Debt free sales price{% endtrans %}</span>
 								<span>{{ debt_free_sales_price }}</span>
+							</p>
+						</li>
+					{% endif %}
+          {#
+          {% if (sales_price|render == '0,00€' or sales_price|render == null) and (debt_free_sales_price|render == '0,00€' or debt_free_sales_price|render == null) and right_of_occupancy_payment|render and right_of_occupancy_payment|render != '0,00€' and right_of_occupancy_payment|render != null %}
+						<li class="apartment__details-item">
+							<p>
+								<span>{% trans %}Right of occupancy payment{% endtrans %}</span>
+								<span>{{ right_of_occupancy_payment }}</span>
+							</p>
+						</li>
+					{% endif %}
+          #}
+          {% if right_of_occupancy_payment|render and right_of_occupancy_payment|render != '0,00€' and right_of_occupancy_payment|render != null %}
+						<li class="apartment__details-item">
+							<p>
+								<span>{% trans %}Right of occupancy payment{% endtrans %}</span>
+								<span>{{ right_of_occupancy_payment }}</span>
+							</p>
+						</li>
+					{% endif %}
+          {% if right_of_occupancy_fee|render and right_of_occupancy_fee|render != '0.00€' %}
+						<li class="apartment__details-item">
+							<p>
+								<span>{% trans %}Right of occupancy fee{% endtrans %}</span>
+								<span>{{ right_of_occupancy_fee }}</span>
+							</p>
+						</li>
+					{% endif %}
+          {% if maintenance_fee|render and maintenance_fee|render != '0.00€ / kk' %}
+						<li class="apartment__details-item">
+							<p>
+								<span>{% trans %}Maintenance fee{% endtrans %}</span>
+								<span>{{ maintenance_fee }}</span>
+							</p>
+						</li>
+					{% endif %}
+          {% if financing_fee|render and financing_fee|render != '0.00€ / month' %}
+						<li class="apartment__details-item">
+							<p>
+								<span>{% trans %}Financing fee{% endtrans %}</span>
+								<span>{{ financing_fee }}</span>
 							</p>
 						</li>
 					{% endif %}


### PR DESCRIPTION
I am not 100% sure if the **right_of_occupancy_payment** field should be included and shown in this template (this was not mentioned in the ticket), but according to the logic we have elsewhere (for example, in the project apartments table we have the logic that _if project type == HASO, show right_of_occupancy_payment field; and if project type == Hitas, show debt_free_sales_price field_), I thought it should be.

Also, I've made **two options** for if statement in the case right_of_occupancy_payment field should be shown on HASO apartments -- one is added and the other one is commented out (see the comment in the file). If right_of_occupancy_payment field should not be shown anyway, both will be removed. 