### PR TITLE
add cache context to menu block

### DIFF
--- a/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
+++ b/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
@@ -133,6 +133,8 @@ function asuntotuotanto_preprocess_menu(&$variables) {
 
     case 'user-tools-menu':
       $items = $variables['items']['asu_user_tools_menu.user_name']['below'];
+      
+      $variables['#cache']['contexts'][] = 'user';
 
       foreach ($items as $key => $item) {
         $url = $item['url']->toString();


### PR DESCRIPTION
Updated header user menu cache context

Make fresh
Login as any customer or salesperson
Make sure caches are cleared
Go to a content page
Login as another user
Go to the same content page

You should see your own username/email address in header

