### PR TITLE
ASU-1300: stop forcing download

### DIFF
--- a/public/themes/custom/asuntotuotanto/templates/content/node--project--full.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/content/node--project--full.html.twig
@@ -381,7 +381,7 @@
               {% set uri = attachment.uri %}
 
               <li class="project__attachment-item">
-                <a href="{{ uri }}" download="{{ description ?: name }}" class="project__attachment-link">
+                <a href="{{ uri }}" class="project__attachment-link">
                   {% include "@hdbt/misc/icon.twig" with {icon: 'document', label: ''} %}
                   <div class="project__attachment-content">
                     <p class="project__attachment-description">{{ 'Download'|t }}</p>


### PR DESCRIPTION
On project's page, attachments are no longer forced to be downloaded. User can preview it with browser.