### PR TITLE
contains nonaggregated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -153,7 +153,8 @@
                 "https://www.drupal.org/project/drupal/issues/2466553": "https://www.drupal.org/files/issues/2020-05-14/2466553-75-d91x.patch",
                 "Views attachments are not rendered in the specified order [https://www.drupal.org/project/drupal/issues/2943293]": "https://www.drupal.org/files/issues/2019-05-25/2943293-17.patch",
                 "Fix admin language preference breaking rest api endpoints": "https://www.drupal.org/files/issues/2021-10-22/2706241-59.patch",
-                "Add remove button and functionality to fields with add-more button": "https://www.drupal.org/files/issues/2021-12-01/1038316-242.patch"
+                "Add remove button and functionality to fields with add-more button": "https://www.drupal.org/files/issues/2021-12-01/1038316-242.patch",
+                "https://www.drupal.org/project/drupal/issues/3098307": "https://www.drupal.org/files/issues/2021-08-20/sql_mode_d9_fullgroupby_3098307.patch"
             },
             "drupal/elasticsearch_connector": {
                 "Custom patch based on https://www.drupal.org/files/issues/2020-03-03/8.x-7.x-2977537-13-array-vs-scalar_0.patch": "patches/elasticsearch_connector_indexfactory_v3.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "848d53a5dc589a0b18ef853d898e2a7f",
+    "content-hash": "6159af277481b8cca4bbf63fe346a3d7",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/public/modules/custom/asu_application/src/Entity/Application.php
+++ b/public/modules/custom/asu_application/src/Entity/Application.php
@@ -301,7 +301,7 @@ class Application extends EditorialContentEntityBase implements ContentEntityInt
     $values += [
       'uid' => $user_id,
       'project_id' => $project_id,
-      'project' => $project_id
+      'project' => $project_id,
     ];
 
   }

--- a/public/modules/custom/asu_rest/src/Plugin/rest/resource/Initialize.php
+++ b/public/modules/custom/asu_rest/src/Plugin/rest/resource/Initialize.php
@@ -143,7 +143,7 @@ final class Initialize extends ResourceBase {
     $return = [];
     foreach ($apartmentIds as $key => $result) {
       if (in_array($projectIds[$apartmentIds[$key]->entity_id], $reservedStates)) {
-        if ($applicationCountByApartment[$key]->state == null) {
+        if ($applicationCountByApartment[$key]->state == NULL) {
           continue;
         }
         $return[$result->entity_id][$key] = strtoupper($applicationCountByApartment[$key]->state);


### PR DESCRIPTION
### Description

Sql problems with xpression #2 of SELECT list is not in GROUP BY clause and contains nonaggregated column

`"SQLSTATE[42000]: Syntax error or access violation: 1055 Expression #2 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'asuntotuotantotestnew.state.field_apartment_state_of_sale_target_id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by: select apt.apartment_id, state.field_apartment_state_of_sale_target_id as `state`, count(apt.apartment_id) as `count`
        from asu_application__apartment as apt
        left join node__field_apartment_state_of_sale as state on apt.apartment_id = state.entity_id
        group by apt.apartment_id; Array
(
)`



