### PR TITLE
sales application bug fix

### DIFF
--- a/public/modules/custom/asu_application/src/Event/SalesApplicationEvent.php
+++ b/public/modules/custom/asu_application/src/Event/SalesApplicationEvent.php
@@ -39,13 +39,6 @@ class SalesApplicationEvent extends Event {
   private string $projectUuid;
 
   /**
-   * Selected apartments.
-   *
-   * @var array
-   */
-  private array $apartmentUuids;
-
-  /**
    * {@inheritdoc}
    */
   public function __construct(
@@ -53,12 +46,11 @@ class SalesApplicationEvent extends Event {
     string $applicationId,
     string $projectName,
     string $projectUuid,
-    array $apartmentUuids) {
+  ) {
     $this->senderId = $senderId;
     $this->applicationId = $applicationId;
     $this->projectName = $projectName;
     $this->projectUuid = $projectUuid;
-    $this->apartmentUuids = $apartmentUuids;
   }
 
   /**
@@ -90,13 +82,6 @@ class SalesApplicationEvent extends Event {
    */
   public function getProjectUuid(): string {
     return $this->projectUuid;
-  }
-
-  /**
-   * Get selected apartments' uuids.
-   */
-  public function getApartmentUuids(): array {
-    return $this->apartmentUuids;
   }
 
 }


### PR DESCRIPTION
### Description

`ArgumentCountError: Too few arguments to function Drupal\asu_application\Event\SalesApplicationEvent::__construct(), 4 passed in /var/www/html/public/modules/custom/asu_application/src/Form/ApplicationForm.php on line 290 and exactly 5 expected in Drupal\asu_application\Event\SalesApplicationEvent->__construct() (line 51 of /var/www/html/public/modules/custom/asu_application/src/Event/SalesApplicationEvent.`