### PR TITLE
Added no current pw because users login suomi and not need or know pw

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         "drupal/matomo_reports": "^1.1",
         "drupal/menu_block": "1.x-dev#17bc5a2094dec85a921fdac6aff0030bfe004744",
         "drupal/menu_link_attributes": "^1.2",
+        "drupal/nocurrent_pass": "^1.2",
         "drupal/paragraphs": "^1.12",
         "drupal/paragraphs_asymmetric_translation_widgets": "^1.0@beta",
         "drupal/pathauto": "^1.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8153b9675b9173216210003667a3b752",
+    "content-hash": "0b7de1704bd5ebc7ee03469bda5b0779",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -6892,6 +6892,62 @@
                 "source": "https://git.drupalcode.org/project/metatag",
                 "issues": "https://www.drupal.org/project/issues/metatag",
                 "docs": "https://www.drupal.org/docs/8/modules/metatag"
+            }
+        },
+        {
+            "name": "drupal/nocurrent_pass",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/nocurrent_pass.git",
+                "reference": "8.x-1.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/nocurrent_pass-8.x-1.2.zip",
+                "reference": "8.x-1.2",
+                "shasum": "507a615ea1a0ea94816c1ff7b29b3982c8db3bd0"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.2",
+                    "datestamp": "1662559302",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "DarrellDuane",
+                    "homepage": "https://www.drupal.org/user/142816"
+                },
+                {
+                    "name": "david.czinege",
+                    "homepage": "https://www.drupal.org/user/2795337"
+                },
+                {
+                    "name": "earthday47",
+                    "homepage": "https://www.drupal.org/user/605842"
+                },
+                {
+                    "name": "shkiper",
+                    "homepage": "https://www.drupal.org/user/2261152"
+                }
+            ],
+            "description": "Make the \"current password\" requirement on the user edit form optional.",
+            "homepage": "https://www.drupal.org/project/nocurrent_pass",
+            "support": {
+                "source": "https://git.drupalcode.org/project/nocurrent_pass"
             }
         },
         {

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -120,6 +120,7 @@ module:
   metatag_views: 0
   migrate: 0
   mysql: 0
+  nocurrent_pass: 0
   node: 0
   oembed_providers: 0
   openid_connect: 0

--- a/conf/cmi/nocurrent_pass.settings.yml
+++ b/conf/cmi/nocurrent_pass.settings.yml
@@ -1,0 +1,3 @@
+_core:
+  default_config_hash: FWe5O-O_9qDKfmsdqG7zujOkV3AO8ldbb-Mg4V2BCDU
+nocurrent_pass_disabled: 1


### PR DESCRIPTION
### Description

Site is using suomi.fi to login users and there are case where email is not get it from suomi.fi. If user fill email address and try to save then Drupal gives error from not insert your current pw. This option now removes requirement to fill current pw because suomi fi login system is not using pw's.