### PR TITLE
Dockerfile: Set max upload file size to 64M

### DIFF
--- a/docker/openshift/Dockerfile
+++ b/docker/openshift/Dockerfile
@@ -1,6 +1,11 @@
 ARG DRUPAL_DOCKER_TAG=8.1
 FROM ghcr.io/city-of-helsinki/drupal-docker-base:${DRUPAL_DOCKER_TAG}
 
+# Override PHP's maximum upload file size and post max size
+RUN sed -i -E \
+    's/^(upload_max_filesize|post_max_size)=.*/\1=64M/' \
+    /etc/php81/conf.d/php-overrides.ini
+
 COPY / /var/www/html/
 WORKDIR /var/www/html
 RUN composer install --no-progress --profile --prefer-dist --no-interaction --no-dev --optimize-autoloader


### PR DESCRIPTION
Override couple file size limits in php-overrides.ini which are set in the drupal-docker-base image initially to 32M, and raise them to 64M.