### PR TITLE
asu_user: Fix name of the external NIN field (ASU-1703)

### DIFF
--- a/conf/cmi/asu_user.external_user_fields.yml
+++ b/conf/cmi/asu_user.external_user_fields.yml
@@ -30,4 +30,4 @@ external_data_map:
   pid:
     title: PID
     type: textfield
-    external_field: personal_identification_number
+    external_field: national_identification_number

--- a/public/modules/custom/asu_user/src/AuthService.php
+++ b/public/modules/custom/asu_user/src/AuthService.php
@@ -163,7 +163,7 @@ class AuthService extends SamlService {
           'first_name' => $first_name,
           'last_name' => $lastname,
           'date_of_birth' => $birth_day,
-          'personal_identification_number' => $pid,
+          'national_identification_number' => $pid,
         ];
 
         $request = new CreateUserRequest(


### PR DESCRIPTION
The National Identification Number (aka NIN, or HETU = Henkilötunnus, or PIN = Personal Identification Number) is accessed with a field named "national_identification_number" in the apartment application service API.  Fix the asu_user requests to use the correct field name.