### PR TITLE
Fix getApplicant method naming

### DIFF
--- a/public/modules/custom/asu_api/src/Api/BackendApi/Request/CreateApplicationRequest.php
+++ b/public/modules/custom/asu_api/src/Api/BackendApi/Request/CreateApplicationRequest.php
@@ -53,7 +53,7 @@ class CreateApplicationRequest extends Request {
       'application_type' => $this->application->bundle(),
       'ssn_suffix' => $this->application->main_applicant[0]->personal_id,
       'has_children' => $this->application->getHasChildren(),
-      'additional_applicant' => $this->getApplicant(),
+      'additional_applicant' => $this->getAdditionalApplicant(),
       'right_of_residence' => NULL,
       'project_id' => $this->projectUuid,
       'apartments' => $this->getApartments(),
@@ -105,11 +105,11 @@ class CreateApplicationRequest extends Request {
    * @return object
    *   Applicant information.
    */
-  protected function getApplicant(): ?object {
+  protected function getAdditionalApplicant(): ?object {
     if (!$this->application->hasAdditionalApplicant()) {
       return NULL;
     }
-    $applicant = $this->application->getApplicant()[0];
+    $applicant = $this->application->getAdditionalApplicants()[0];
     return (object) [
       'first_name' => $applicant['first_name'],
       'last_name' => $applicant['last_name'],

--- a/public/modules/custom/asu_api/src/Api/BackendApi/Request/SalesCreateApplicationRequest.php
+++ b/public/modules/custom/asu_api/src/Api/BackendApi/Request/SalesCreateApplicationRequest.php
@@ -61,7 +61,7 @@ class SalesCreateApplicationRequest extends Request {
       'application_type' => $this->application->bundle(),
       'ssn_suffix' => $this->application->main_applicant[0]->personal_id,
       'has_children' => $this->application->getHasChildren(),
-      'additional_applicant' => $this->getApplicant(),
+      'additional_applicant' => $this->getAdditionalApplicant(),
       'right_of_residence' => NULL,
       'is_new_permit_number' => NULL,
       'project_id' => $this->projectUuid,
@@ -115,11 +115,11 @@ class SalesCreateApplicationRequest extends Request {
    * @return array
    *   Applicant information.
    */
-  private function getApplicant() {
+  private function getAdditionalApplicant() {
     if (!$this->application->hasAdditionalApplicant()) {
       return NULL;
     }
-    $applicant = $this->application->getApplicants()[0];
+    $applicant = $this->application->getAdditionalApplicants()[0];
     return [
       'first_name' => $applicant['first_name'],
       'last_name' => $applicant['last_name'],

--- a/public/modules/custom/asu_application/src/Entity/Application.php
+++ b/public/modules/custom/asu_application/src/Entity/Application.php
@@ -144,7 +144,7 @@ class Application extends EditorialContentEntityBase implements ContentEntityInt
    * @return array
    *   Array of applicants.
    */
-  public function getApplicant(): array {
+  public function getAdditionalApplicants(): array {
     return $this->applicant->getValue() ?? [];
   }
 


### PR DESCRIPTION
Use better method name "getAdditionalApplicant" in the CreateApplicationRequest and SalesCreateApplicationRequest and "getAdditionalApplicants" in Application.

This should make the code less confusing, since it's now clear that there are indeed ADDITIONAL applicants and that the one that returns an array has the "s" in the end of the name for plural.

This fixes a bug in SalesCreateApplicationRequest, which used to call `application->getApplicants()` but the method name was previously `getApplicant`.