### PR TITLE
SATT-13: Hide unpulished, solded or reserved apartments

### DIFF
--- a/public/modules/custom/asu_application/src/Form/ApplicationForm.php
+++ b/public/modules/custom/asu_application/src/Form/ApplicationForm.php
@@ -54,7 +54,8 @@ class ApplicationForm extends ContentEntityForm {
       return (new RedirectResponse($redirect, 301));
     }
 
-    if (!$project_data = $this->getApartments($project, ['sold', 'reserved', 'reserved_haso'])) {
+    $limit = ['sold', 'reserved', 'reserved_haso'];
+    if (!$project_data = $this->getApartments($project, $limit)) {
       $this->logger('asu_application')->critical('User tried to access nonexistent project of id ' . $project_id);
       $this->messenger()->addMessage($this->t('Unfortunately the project you are trying to apply for is unavailable.'));
       return new RedirectResponse($applicationsUrl);
@@ -357,7 +358,7 @@ class ApplicationForm extends ContentEntityForm {
       foreach ($project->field_apartments as $apartmentReference) {
         $apartment = $apartmentReference->entity;
         // Skip unpublish apartments.
-        if( $apartment->get('status')->value == 0) {
+        if ($apartment->get('status')->value == 0) {
           continue;
         }
 


### PR DESCRIPTION
### Description

Hide unpublished, reserved and solded apartments from application form


### How to test it

- make fresh
- login as admin
- re index both search api indexes https://asuntotuotanto.docker.so/fi/admin/config/search/search-api
- Go hitas  https://asuntotuotanto.docker.so/fi/asuntohaku/hitas or hasohttps://asuntotuotanto.docker.so/fi/asuntohaku/haso  listing page 
- Edit some project and set application ending date up to future and check also that all required values are set that project can get applications (No documentation so i dont know which values must be what... Good luck)
- i used Gunillantie 4 just extend ending date to future https://asuntotuotanto.docker.so/fi/node/7518
- now you can see on project page which apartments are sold, reserved...
- now click luo hakemus and check that only Vapaa apartments are found in apartment list

![CleanShot 2023-12-18 at 14 34 48](https://github.com/City-of-Helsinki/drupal-asuntotuotanto/assets/5573746/2400f421-e587-49b4-9aa9-9b9c118a8bae)

![CleanShot 2023-12-18 at 14 35 19](https://github.com/City-of-Helsinki/drupal-asuntotuotanto/assets/5573746/84e0bd87-2293-4390-9f60-2789b67fa3b1)
