### PR TITLE
SATT-8: Website time works incorrectly

### DIFF
--- a/public/modules/custom/asu_application/src/Form/ApplicationForm.php
+++ b/public/modules/custom/asu_application/src/Form/ApplicationForm.php
@@ -629,4 +629,5 @@ class ApplicationForm extends ContentEntityForm {
 
     return $date;
   }
+
 }

--- a/public/modules/custom/asu_application/src/Form/ApplicationForm.php
+++ b/public/modules/custom/asu_application/src/Form/ApplicationForm.php
@@ -586,9 +586,9 @@ class ApplicationForm extends ContentEntityForm {
     if (!$startDate || !$endDate) {
       return FALSE;
     }
-    $startDate = $this->convertDatetime($startDate);
+    $startDate = asu_content_convert_datetime($startDate);
     $startDate = strtotime($startDate);
-    $endDate = $this->convertDatetime($endDate);
+    $endDate = asu_content_convert_datetime($endDate);
     $endDate = strtotime($endDate);
     $now = time();
 
@@ -612,22 +612,6 @@ class ApplicationForm extends ContentEntityForm {
     }
 
     return $value;
-  }
-
-  /**
-   * Covert datetime.
-   */
-  private function convertDatetime($value) {
-    /** @var Drupal\Core\Datetime\DateFormatterInterface $date_formatter */
-    $date_formatter = \Drupal::service('date.formatter');
-    $date = $date_formatter->format(
-      strtotime($value . ' UTC'),
-      'custom',
-      'Y-m-d\TH:i:sP',
-      'Europe/Helsinki',
-    );
-
-    return $date;
   }
 
 }

--- a/public/modules/custom/asu_application/src/Form/ApplicationForm.php
+++ b/public/modules/custom/asu_application/src/Form/ApplicationForm.php
@@ -586,25 +586,27 @@ class ApplicationForm extends ContentEntityForm {
     if (!$startDate || !$endDate) {
       return FALSE;
     }
-    $startTime = strtotime($startDate);
-    $endTime = strtotime($endDate);
+    $startDate = $this->convertDatetime($startDate);
+    $startDate = strtotime($startDate);
+    $endDate = $this->convertDatetime($endDate);
+    $endDate = strtotime($endDate);
     $now = time();
 
     $value = FALSE;
 
     switch ($period) {
       case "before":
-        $value = $now < $startTime;
+        $value = $now < $startDate;
 
         break;
 
       case "now":
-        $value = $now > $startTime && $now < $endTime;
+        $value = $now > $startDate && $now < $endDate;
 
         break;
 
       case "after":
-        $value = $now > $endTime;
+        $value = $now > $endDate;
 
         break;
     }
@@ -612,4 +614,19 @@ class ApplicationForm extends ContentEntityForm {
     return $value;
   }
 
+  /**
+   * Covert datetime.
+   */
+  private function convertDatetime($value) {
+    /** @var Drupal\Core\Datetime\DateFormatterInterface $date_formatter */
+    $date_formatter = \Drupal::service('date.formatter');
+    $date = $date_formatter->format(
+      strtotime($value . ' UTC'),
+      'custom',
+      'Y-m-d\TH:i:sP',
+      'Europe/Helsinki',
+    );
+
+    return $date;
+  }
 }

--- a/public/modules/custom/asu_content/asu_content.module
+++ b/public/modules/custom/asu_content/asu_content.module
@@ -376,3 +376,19 @@ function asuSetQueueWorker($project) {
     }
   }
 }
+
+/**
+ * Covert datetime.
+ */
+function asu_content_convert_datetime($value): string {
+    /** @var Drupal\Core\Datetime\DateFormatterInterface $date_formatter */
+    $date_formatter = \Drupal::service('date.formatter');
+    $date = $date_formatter->format(
+      strtotime($value . ' UTC'),
+      'custom',
+      'Y-m-d\TH:i:sP',
+      'Europe/Helsinki',
+    );
+
+    return $date;
+}

--- a/public/modules/custom/asu_content/src/Entity/Project.php
+++ b/public/modules/custom/asu_content/src/Entity/Project.php
@@ -36,9 +36,9 @@ class Project extends Node {
         !$this->field_application_end_time->value) {
       return FALSE;
     }
-    $startTime = $this->convertDatetime($this->field_application_start_time->value);
+    $startTime = asu_content_convert_datetime($this->field_application_start_time->value);
     $startTime = strtotime($startTime);
-    $endTime = $this->convertDatetime($this->field_application_end_time->value);
+    $endTime = asu_content_convert_datetime($this->field_application_end_time->value);
     $endTime = strtotime($endTime);
     $now = time();
 
@@ -152,22 +152,6 @@ class Project extends Node {
     }
 
     return $user_field->referencedEntities()[0];
-  }
-
-  /**
-   * Covert datetime.
-   */
-  private function convertDatetime($value) {
-    /** @var Drupal\Core\Datetime\DateFormatterInterface $date_formatter */
-    $date_formatter = \Drupal::service('date.formatter');
-    $date = $date_formatter->format(
-      strtotime($value . ' UTC'),
-      'custom',
-      'Y-m-d\TH:i:sP',
-      'Europe/Helsinki',
-    );
-
-    return $date;
   }
 
 }

--- a/public/modules/custom/asu_elastic/src/Plugin/search_api/data_type/AsuDateTime.php
+++ b/public/modules/custom/asu_elastic/src/Plugin/search_api/data_type/AsuDateTime.php
@@ -28,32 +28,16 @@ class AsuDateTime extends DataTypePluginBase {
       $dates = [];
 
       foreach ($value as $date) {
-        $dates[] = $this->convertDatetime($date);
+        $dates[] = asu_content_convert_datetime($date);
       }
 
       $newvalue = $dates;
     }
     else {
-      $newvalue = $this->convertDatetime($value);
+      $newvalue = asu_content_convert_datetime($value);
     }
 
     return $newvalue;
-  }
-
-  /**
-   * Covert datetime.
-   */
-  private function convertDatetime($value) {
-    /** @var Drupal\Core\Datetime\DateFormatterInterface $date_formatter */
-    $date_formatter = \Drupal::service('date.formatter');
-    $date = $date_formatter->format(
-      strtotime($value . ' UTC'),
-      'custom',
-      'Y-m-d\TH:i:sP',
-      'Europe/Helsinki',
-    );
-
-    return $date;
   }
 
 }


### PR DESCRIPTION
## Ticket:
https://andersinno.atlassian.net/browse/SATT-8

## In this PR:
The closing time for application forms were closing 2 hours before they were supposed to. Adding the time conversion to Finnish time before comparing it solves this issue.

## Testing guidance:
`make fresh`
- Go to omistusasunnot -> Tutustu kohteeseen (any on going or closed one) edit the node 
- Go to aikataulut tab ![image](https://github.com/City-of-Helsinki/drupal-asuntotuotanto/assets/98033579/9694966c-1ae6-40ff-9f69-b65e55f7d668)
- Edit the "Hakuajan päättymisaika" So that the value is in the past
- Confirm you are not able to apply for appartments 
![image](https://github.com/City-of-Helsinki/drupal-asuntotuotanto/assets/98033579/5bbec889-c758-4712-8847-4afcd089b3ae)
- Edit the "Hakuajan päättymisaika" So that the value is 30 min later than current your current time (Time now 12:00, Hakuajan päättymisaika 12:30 ![image](https://github.com/City-of-Helsinki/drupal-asuntotuotanto/assets/98033579/5b7a2b53-2864-4605-8499-341c4abde526)
- Click "Lähetä" 
![image](https://github.com/City-of-Helsinki/drupal-asuntotuotanto/assets/98033579/f7185033-5809-45ea-b7c5-39741654fd61)
- Scroll down the page and confirm clicking the "Luo hakemus" takes you to the application page 
![image](https://github.com/City-of-Helsinki/drupal-asuntotuotanto/assets/98033579/05f23597-6fb1-472c-a361-46ceda66b187)


