### PR TITLE
SATT-9: Default language fi and show language select on edit

### DIFF
--- a/conf/cmi/core.entity_form_display.user.customer.default.yml
+++ b/conf/cmi/core.entity_form_display.user.customer.default.yml
@@ -26,13 +26,17 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  language:
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   contact: true
   field_backend_password: true
   field_backend_profile: true
   field_email_is_valid: true
   langcode: true
-  language: true
   matomo: true
   path: true
   translation: true

--- a/public/modules/custom/asu_user/src/AuthService.php
+++ b/public/modules/custom/asu_user/src/AuthService.php
@@ -138,6 +138,8 @@ class AuthService extends SamlService {
           'name' => $name,
           'type' => 'customer',
           'langcode' => 'fi',
+          'preferred_langcode' => 'fi',
+          'preferred_admin_langcode' => 'fi',
           'field_saml_hash' => $unique_id,
         ];
 


### PR DESCRIPTION
### Description

Set a new user default language fi and show language selection on user edit form


### How to test it

- Setup suomifi authentication on local docker
- make fresh
- login some user which is not already login
  - You can check on your database
- check that after login that user language is finnish