### PR TITLE
SATT-28: 28: saml authentication already exists fix

### DIFF
--- a/public/modules/custom/asu_user/src/AuthService.php
+++ b/public/modules/custom/asu_user/src/AuthService.php
@@ -130,7 +130,7 @@ class AuthService extends SamlService {
     if (!$account) {
       if ($config->get('create_users')) {
         $attributes = $this->getAttributes();
-        $name = reset($attributes['displayName']);
+        $name = $this->getAccountUsername(reset($attributes['displayName']));
         $mail = (isset($attributes['mail'])) ? reset($attributes['mail']) : NULL;
 
         $account_data = [
@@ -235,6 +235,25 @@ class AuthService extends SamlService {
     $hash = Crypt::hmacBase64($string, $hash_key);
 
     return $hash;
+  }
+
+  private function getAccountUsername($user_name) {
+    $query = \Drupal::database()->select('users_field_data', 'u');
+    $query->fields('u', ['name']);
+    // OR CONDITION
+    $or_group = $query->orConditionGroup();
+    $or_group->condition('name', $query->escapeLike($user_name));
+    $or_group->condition('name', $user_name . '_[0-9]', 'REGEXP');
+    // Added OR CONDITION TO QUERY.
+    $query->condition($or_group);
+    $result = $query->execute()->fetchAll();
+    $result_count = count($result);
+
+    if ($result_count > 0) {
+      return $user_name . '_' . $result_count + 1;
+    }
+
+    return $user_name;
   }
 
 }


### PR DESCRIPTION
### Description

Suomi authentication (SAML) user name already exists fix

### How to test

- Setup suomi fi auhentication on your local
- make fresh or make up
- login as admin
- go user listing https://asuntotuotanto.docker.so/fi/admin/people
- create 1-2 a new users
- open sql and go check users_field_data table
- now edit those a new users name column value to Antero Asiakas_1 and Antero Asiakas_2....
- logout or open different browser or incognito mode front page
- now login on kirjaudu
- use OP and do the login
- check that you can login with Antero Asiakas
- check on database users_field_data that latest Antero Asiakas name is Antero Asiakas_XX