### PR TITLE
SATT-30: Apartment free status fix

### DIFF
--- a/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
+++ b/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
@@ -235,7 +235,7 @@ function asuntotuotanto_preprocess_views_view_table(&$variables) {
       $variables['rows'][$key]['application_status'] = get_apartment_application_status($applicationCountEnum);
 
       $reserved_or_sold = FALSE;
-      if ($apartment->isSold() || $apartment->isReserved() || $apartment->isFree()) {
+      if ($apartment->isSold() || $apartment->isReserved()) {
         $reserved_or_sold = $apartment->isReserved() ? t('Reserved') : t('Vacant');
         // Set application status to HIGH if apartment is reserved.
         $variables['rows'][$key]['application_status']['status'] = $apartment->isReserved() ? 'high' : 'low';
@@ -243,6 +243,9 @@ function asuntotuotanto_preprocess_views_view_table(&$variables) {
         if ($apartment->isSold()) {
           $reserved_or_sold = t('Sold');
         }
+      }
+      else if ($apartment->isFree()) {
+        $reserved_or_sold = t('Free');
       }
 
       if (!$project) {

--- a/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
+++ b/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
@@ -244,7 +244,7 @@ function asuntotuotanto_preprocess_views_view_table(&$variables) {
           $reserved_or_sold = t('Sold');
         }
       }
-      else if ($apartment->isFree()) {
+      else if ($apartment->isFree() || !$apartment->isReserved()) {
         $reserved_or_sold = t('Free');
       }
 

--- a/public/themes/custom/asuntotuotanto/templates/views/project/views-view-table--project-apartments-listing.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/views/project/views-view-table--project-apartments-listing.html.twig
@@ -268,6 +268,7 @@
 
               {% if reserved_or_sold %}
                 {% trans %}
+                  <span aria-hidden="true" class="project__apartment-application-status project__apartment-application-status--{{ application_status.status|trim }}"></span>
                   {{ reserved_or_sold }}
                 {% endtrans %}
               {% else %}


### PR DESCRIPTION
### Description

Fix apartment page statuses. Current version is not show free statuses on project page.

https://andersinno.atlassian.net/browse/SATT-30

### How to test it

- make fresh
- login as admin
- go index apartment listing search index https://asuntotuotanto.docker.so/fi/admin/config/search/search-api
- now go haso or hitas listing page https://asuntotuotanto.docker.so
- check some New haettava is possible and check project apartment statuses
- now open that project in a new tab
- check and compare that apartment statuses are same
- you can open project on edit mode and check there apartment statuses
- you can also test Free text translation by adding it https://asuntotuotanto.docker.so/fi/admin/config/regional/translate