### PR TITLE
revert react 1.3.5 to 1.3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -173,9 +173,9 @@
             "type": "package",
             "package": {
                 "name": "asuntomyynti/react",
-                "version": "1.3.5",
+                "version": "1.3.4",
                 "dist": {
-                    "url": "https://github.com/City-of-Helsinki/asuntomyynti-react/archive/refs/tags/v1.3.5.zip",
+                    "url": "https://github.com/City-of-Helsinki/asuntomyynti-react/releases/download/v1.3.4/asuntomyynti-react-1.3.4.zip",
                     "type": "zip"
                 }
             }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7c771bfac8e6a427640f342a3d1c1003",
+    "content-hash": "5396fdcc051e6c07693e2a8847df4162",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -64,10 +64,10 @@
         },
         {
             "name": "asuntomyynti/react",
-            "version": "1.3.5",
+            "version": "1.3.4",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/City-of-Helsinki/asuntomyynti-react/archive/refs/tags/v1.3.5.zip"
+                "url": "https://github.com/City-of-Helsinki/asuntomyynti-react/releases/download/v1.3.4/asuntomyynti-react-1.3.4.zip"
             },
             "type": "library"
         },


### PR DESCRIPTION
### Description

Revert react package 1.3.5 to 1.3.4

### how to test it

- make fresh
- login as admin
- re-index apartment listing https://asuntotuotanto.docker.so/fi/admin/config/search/search-api/index/apartment_listing
- clear cache
- check that https://asuntotuotanto.docker.so/fi/asuntohaku/haso and https://asuntotuotanto.docker.so/fi/asuntohaku/hitas pages works