### PR TITLE
SATT-39: Update react package v1.3.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -173,9 +173,9 @@
             "type": "package",
             "package": {
                 "name": "asuntomyynti/react",
-                "version": "1.3.8",
+                "version": "1.3.9",
                 "dist": {
-                    "url": "https://github.com/City-of-Helsinki/asuntomyynti-react/releases/download/v1.3.8/asuntomyynti-react-1.3.8.zip",
+                    "url": "https://github.com/City-of-Helsinki/asuntomyynti-react/releases/download/v.1.3.9/asuntomyynti-react-1.3.9.zip",
                     "type": "zip"
                 }
             }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "044e3acca6e44a0fb8dd42ae939cb305",
+    "content-hash": "8e42028ed282c3b77ec52da874de4472",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -64,10 +64,10 @@
         },
         {
             "name": "asuntomyynti/react",
-            "version": "1.3.8",
+            "version": "1.3.9",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/City-of-Helsinki/asuntomyynti-react/releases/download/v1.3.8/asuntomyynti-react-1.3.8.zip"
+                "url": "https://github.com/City-of-Helsinki/asuntomyynti-react/releases/download/v.1.3.9/asuntomyynti-react-1.3.9.zip"
             },
             "type": "library"
         },


### PR DESCRIPTION
### Description

Update react package which fix Haso and Hitas listing page status colors


### How to test it

 - make fresh or make build drush-cr
 - login as admin
 - index apartment listing index https://asuntotuotanto.docker.so/fi/admin/config/search/search-api/index/apartment_listing
 - clear caches on Drupal UI
 - go check hitas and or haso listing pages that varattu (reserved) is red
 - I needed hard refresh before color change shows