### PR TITLE
SATT-39: react package update 1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -173,9 +173,9 @@
             "type": "package",
             "package": {
                 "name": "asuntomyynti/react",
-                "version": "1.3.8",
+                "version": "1.4.0",
                 "dist": {
-                    "url": "https://github.com/City-of-Helsinki/asuntomyynti-react/releases/download/v1.3.8/asuntomyynti-react-1.3.8.zip",
+                    "url": "https://github.com/City-of-Helsinki/asuntomyynti-react/releases/download/v.1.4.0/asuntomyynti-react-1.4.0.zip",
                     "type": "zip"
                 }
             }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "044e3acca6e44a0fb8dd42ae939cb305",
+    "content-hash": "64d7b97bd524a5e12f2ae620d256b536",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -64,10 +64,10 @@
         },
         {
             "name": "asuntomyynti/react",
-            "version": "1.3.8",
+            "version": "1.4.0",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/City-of-Helsinki/asuntomyynti-react/releases/download/v1.3.8/asuntomyynti-react-1.3.8.zip"
+                "url": "https://github.com/City-of-Helsinki/asuntomyynti-react/releases/download/v.1.4.0/asuntomyynti-react-1.4.0.zip"
             },
             "type": "library"
         },


### PR DESCRIPTION
### Description
Update react package which fix Haso and Hitas listing page status colors

### How to test it

- make fresh or make build drush-cr
- login as admin
- index apartment listing index https://asuntotuotanto.docker.so/fi/admin/config/search/search-api/index/apartment_listing
- clear caches on Drupal UI
- go check hitas and or haso listing pages that varattu (reserved) is red
- I needed hard refresh before color change shows