### PR TITLE
SATT-54: Added HASO fee field in apartments

### DIFF
--- a/conf/cmi/asu_csv_import.haso_apartment_fields.yml
+++ b/conf/cmi/asu_csv_import.haso_apartment_fields.yml
@@ -6,7 +6,7 @@ apartment_fields:
   - empty
   - field_right_of_occupancy_fee
   - field_right_of_occupancy_deposit
-  - field_right_of_occupancy_payment
+  - field_haso_fee
   - field_floor_max
   - field_water_fee
   - field_water_fee_explanation

--- a/conf/cmi/core.entity_form_display.node.apartment.default.yml
+++ b/conf/cmi/core.entity_form_display.node.apartment.default.yml
@@ -22,6 +22,7 @@ dependencies:
     - field.field.node.apartment.field_has_balcony
     - field.field.node.apartment.field_has_terrace
     - field.field.node.apartment.field_has_yard
+    - field.field.node.apartment.field_haso_fee
     - field.field.node.apartment.field_images
     - field.field.node.apartment.field_index_adjusted_right_of_oc
     - field.field.node.apartment.field_kitchen_appliances
@@ -57,6 +58,7 @@ dependencies:
     - image
     - link
     - path
+    - publication_date
     - scheduler
 third_party_settings:
   field_group:
@@ -120,6 +122,7 @@ third_party_settings:
         - field_sales_price
         - field_debt_free_sales_price
         - field_release_payment
+        - field_haso_fee
         - field_right_of_occupancy_fee
         - field_right_of_occupancy_deposit
         - field_right_of_occupancy_payment
@@ -165,7 +168,7 @@ content:
     third_party_settings: {  }
   field_alteration_work:
     type: number
-    weight: 48
+    weight: 49
     region: content
     settings:
       placeholder: ''
@@ -238,7 +241,7 @@ content:
     third_party_settings: {  }
   field_financing_fee:
     type: number
-    weight: 50
+    weight: 51
     region: content
     settings:
       placeholder: ''
@@ -293,6 +296,13 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
+  field_haso_fee:
+    type: number
+    weight: 44
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
   field_images:
     type: image_image
     weight: 26
@@ -303,7 +313,7 @@ content:
     third_party_settings: {  }
   field_index_adjusted_right_of_oc:
     type: number
-    weight: 47
+    weight: 48
     region: content
     settings:
       placeholder: ''
@@ -325,21 +335,21 @@ content:
     third_party_settings: {  }
   field_loan_share:
     type: number
-    weight: 49
+    weight: 50
     region: content
     settings:
       placeholder: ''
     third_party_settings: {  }
   field_maintenance_fee:
     type: number
-    weight: 51
+    weight: 52
     region: content
     settings:
       placeholder: ''
     third_party_settings: {  }
   field_other_fees:
     type: string_textarea
-    weight: 56
+    weight: 57
     region: content
     settings:
       rows: 5
@@ -347,14 +357,14 @@ content:
     third_party_settings: {  }
   field_parking_fee:
     type: number
-    weight: 54
+    weight: 55
     region: content
     settings:
       placeholder: ''
     third_party_settings: {  }
   field_parking_fee_explanation:
     type: string_textarea
-    weight: 55
+    weight: 56
     region: content
     settings:
       rows: 5
@@ -383,21 +393,21 @@ content:
     third_party_settings: {  }
   field_right_of_occupancy_deposit:
     type: number
-    weight: 45
+    weight: 46
     region: content
     settings:
       placeholder: ''
     third_party_settings: {  }
   field_right_of_occupancy_fee:
     type: number
-    weight: 44
+    weight: 45
     region: content
     settings:
       placeholder: ''
     third_party_settings: {  }
   field_right_of_occupancy_payment:
     type: number
-    weight: 46
+    weight: 47
     region: content
     settings:
       placeholder: ''
@@ -462,14 +472,14 @@ content:
     third_party_settings: {  }
   field_water_fee:
     type: number
-    weight: 52
+    weight: 53
     region: content
     settings:
       placeholder: ''
     third_party_settings: {  }
   field_water_fee_explanation:
     type: string_textarea
-    weight: 53
+    weight: 54
     region: content
     settings:
       rows: 5

--- a/conf/cmi/core.entity_view_display.node.apartment.default.yml
+++ b/conf/cmi/core.entity_view_display.node.apartment.default.yml
@@ -22,6 +22,7 @@ dependencies:
     - field.field.node.apartment.field_has_balcony
     - field.field.node.apartment.field_has_terrace
     - field.field.node.apartment.field_has_yard
+    - field.field.node.apartment.field_haso_fee
     - field.field.node.apartment.field_images
     - field.field.node.apartment.field_index_adjusted_right_of_oc
     - field.field.node.apartment.field_kitchen_appliances
@@ -236,6 +237,17 @@ content:
       format_custom_true: ''
     third_party_settings: {  }
     weight: 10
+    region: content
+  field_haso_fee:
+    type: number_decimal
+    label: above
+    settings:
+      thousand_separator: ''
+      decimal_separator: .
+      scale: 2
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 66
     region: content
   field_housing_manager:
     type: string

--- a/conf/cmi/core.entity_view_display.node.apartment.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.apartment.teaser.yml
@@ -23,6 +23,7 @@ dependencies:
     - field.field.node.apartment.field_has_balcony
     - field.field.node.apartment.field_has_terrace
     - field.field.node.apartment.field_has_yard
+    - field.field.node.apartment.field_haso_fee
     - field.field.node.apartment.field_images
     - field.field.node.apartment.field_index_adjusted_right_of_oc
     - field.field.node.apartment.field_kitchen_appliances
@@ -105,6 +106,7 @@ hidden:
   field_has_balcony: true
   field_has_terrace: true
   field_has_yard: true
+  field_haso_fee: true
   field_housing_company_fee: true
   field_housing_manager: true
   field_images: true

--- a/conf/cmi/field.field.node.apartment.field_haso_fee.yml
+++ b/conf/cmi/field.field.node.apartment.field_haso_fee.yml
@@ -1,0 +1,23 @@
+uuid: 4e5eb76c-0d4c-4fcf-8a82-d3d04682ce7c
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_haso_fee
+    - node.type.apartment
+id: node.apartment.field_haso_fee
+field_name: field_haso_fee
+entity_type: node
+bundle: apartment
+label: 'Alkuperäinen asumisoikeusmaksu'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: €
+field_type: decimal

--- a/conf/cmi/field.field.node.apartment.field_haso_fee.yml
+++ b/conf/cmi/field.field.node.apartment.field_haso_fee.yml
@@ -1,5 +1,5 @@
 uuid: 4e5eb76c-0d4c-4fcf-8a82-d3d04682ce7c
-langcode: fi
+langcode: en
 status: true
 dependencies:
   config:
@@ -9,7 +9,7 @@ id: node.apartment.field_haso_fee
 field_name: field_haso_fee
 entity_type: node
 bundle: apartment
-label: 'Alkuperäinen asumisoikeusmaksu'
+label: 'Original HASO Fee'
 description: ''
 required: false
 translatable: false

--- a/conf/cmi/field.storage.node.field_haso_fee.yml
+++ b/conf/cmi/field.storage.node.field_haso_fee.yml
@@ -1,5 +1,5 @@
 uuid: 615637e4-e1bb-4fbd-8107-26e6fb33bc7b
-langcode: fi
+langcode: en
 status: true
 dependencies:
   module:

--- a/conf/cmi/field.storage.node.field_haso_fee.yml
+++ b/conf/cmi/field.storage.node.field_haso_fee.yml
@@ -1,0 +1,20 @@
+uuid: 615637e4-e1bb-4fbd-8107-26e6fb33bc7b
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_haso_fee
+field_name: field_haso_fee
+entity_type: node
+type: decimal
+settings:
+  precision: 10
+  scale: 2
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/language/fi/field.field.node.apartment.field_haso_fee.yml
+++ b/conf/cmi/language/fi/field.field.node.apartment.field_haso_fee.yml
@@ -1,0 +1,1 @@
+label: 'Alkuperäinen asumisoikeusmaksu'

--- a/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
+++ b/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
@@ -651,7 +651,7 @@ function asuntotuotanto_preprocess_node(&$variables) {
 
         if (
           $project->hasField('field_application_start_time') &&
-          $application_start_time_value = $project->get('field_application_start_time'
+          $project->get('field_application_start_time'
           )->value) {
           $application_start = $date_formatter->format(
             $project->get('field_application_start_time')->date->getTimestamp(),
@@ -659,10 +659,9 @@ function asuntotuotanto_preprocess_node(&$variables) {
             'd.m.Y H:i'
           );
         }
-        if (
-          $project->hasField('field_application_end_time') &&
-          $application_end_time_value = $project->get('field_application_end_time')->value
-        ) {
+        if ($project->hasField('field_application_end_time') &&
+          $project->get('field_application_end_time'
+          )->value) {
           $application_end = $date_formatter->format(
             $project->get('field_application_end_time')->date->getTimestamp(),
             'custom',

--- a/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
@@ -89,6 +89,7 @@
 {% set images = content.field_images %}
 {% set floor = content.field_floor.0 %}
 {% set sales_price = content.field_sales_price.0 %}
+{% set haso_fee = content.field_haso_fee.0 %}
 {% set adjusted_price = content.field_index_adjusted_right_of_oc.0 %}
 {% set alteration_price = content.field_alteration_work.0 %}
 {% set release_payment = content.field_release_payment.0 %}
@@ -385,6 +386,14 @@
 							</p>
 						</li>
 					{% endif %}
+          {% if haso_fee|render and haso_fee|render != '0,00€' and haso_fee|render != null %}
+            <li class="apartment__details-item">
+              <p>
+                <span>{% trans %}Original HASO Fee{% endtrans %}</span>
+                <span>{{ haso_fee }}</span>
+              </p>
+            </li>
+          {% endif %}
 					{% if debt_free_sales_price|render and debt_free_sales_price|render != '0,00€' and debt_free_sales_price|render != null %}
 						<li class="apartment__details-item">
 							<p>


### PR DESCRIPTION
### Description

Added HASO fee field to apartment content type and csv HASO importer


### How to test it

- make fresh
- login as admin
- go edit some project /admin/content
- on project editing form just scroll down on bottom of form
- click Lataa HASO csv-pohja (screenshot 1)
- open that .csv file and check that csv include HASO fee field
- now fill some values to HASO fee columns in csv file and save that file
- create a new project and fill required fields like taloyhtiö and adress
- save project node
- now edit that just created project node
- go huoneistot tab and add that csv-file what you just edited
- save node and check that you dont get errors
- now open some apartments which you add that haso fee and check that haso fee field has value
- also haso fee value should be display on apartment public side when you view the node (screenshot 2)

![CleanShot 2024-05-02 at 15 55 21@2x](https://github.com/City-of-Helsinki/drupal-asuntotuotanto/assets/5573746/bb1e1ef7-514d-48e3-914f-b33609eeb4a0)

![CleanShot 2024-05-02 at 16 02 14@2x](https://github.com/City-of-Helsinki/drupal-asuntotuotanto/assets/5573746/abee9381-d4f6-4c32-b09d-0981b6ea49fe)
