### PR TITLE
SATT-56: exclude non project apartments on elastic search

### DIFF
--- a/conf/cmi/search_api.index.apartment.yml
+++ b/conf/cmi/search_api.index.apartment.yml
@@ -4,51 +4,52 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_additional_information
-    - field.storage.node.field_alteration_work
-    - field.storage.node.field_floor_max
     - field.storage.node.field_apartment_number
     - field.storage.node.field_apartment_state_of_sale
     - field.storage.node.field_apartment_structure
-    - field.storage.node.field_right_of_occupancy_payment
-    - field.storage.node.field_has_balcony
     - field.storage.node.field_balcony_description
     - field.storage.node.field_bathroom_appliances
+    - field.storage.node.field_condition
     - field.storage.node.field_debt_free_sales_price
-    - field.storage.node.field_stock_start_number
+    - field.storage.node.field_alteration_work
+    - field.storage.node.field_index_adjusted_right_of_oc
     - field.storage.node.field_financing_fee
     - field.storage.node.field_floor
+    - field.storage.node.field_floor_max
     - field.storage.node.field_floorplan
-    - field.storage.node.field_condition
-    - field.storage.node.field_index_adjusted_right_of_oc
+    - field.storage.node.field_has_apartment_sauna
+    - field.storage.node.field_has_balcony
+    - field.storage.node.field_has_terrace
+    - field.storage.node.field_has_yard
     - field.storage.node.field_kitchen_appliances
-    - field.storage.node.field_right_of_occupancy_fee
-    - field.storage.node.field_right_of_occupancy_deposit
     - field.storage.node.field_living_area
-    - field.storage.node.field_release_payment
+    - field.storage.node.field_loan_share
     - field.storage.node.field_maintenance_fee
     - field.storage.node.field_other_fees
     - field.storage.node.field_parking_fee
     - field.storage.node.field_parking_fee_explanation
     - field.storage.node.field_publish_on_etuovi
     - field.storage.node.field_publish_on_oikotie
+    - field.storage.node.field_release_payment
+    - field.storage.node.field_right_of_occupancy_deposit
+    - field.storage.node.field_right_of_occupancy_fee
+    - field.storage.node.field_right_of_occupancy_payment
     - field.storage.node.field_sales_price
-    - field.storage.node.field_has_apartment_sauna
     - field.storage.node.field_services_description
-    - field.storage.node.field_loan_share
     - field.storage.node.field_showing_time
-    - field.storage.node.field_storage_description
-    - field.storage.node.field_has_terrace
-    - field.storage.node.field_view_description
     - field.storage.node.field_stock_end_number
+    - field.storage.node.field_stock_start_number
+    - field.storage.node.field_storage_description
+    - field.storage.node.field_view_description
     - field.storage.node.field_water_fee
     - field.storage.node.field_water_fee_explanation
-    - field.storage.node.field_has_yard
     - search_api.server.asuntotuotanto
   module:
+    - computed_field_plugin
     - asu_elastic
     - node
-    - computed_field_plugin
     - search_api
+    - helfi_react_search
 id: apartment
 name: Apartment
 description: ''
@@ -986,6 +987,8 @@ datasource_settings:
 processor_settings:
   add_url: {  }
   aggregated_field: {  }
+  custom_value: {  }
+  district_image_absolute_url: {  }
   entity_type: {  }
   html_filter:
     weights:
@@ -1003,8 +1006,12 @@ processor_settings:
     alt: true
     tags: {  }
   language_with_fallback: {  }
+  project_execution_schedule: {  }
+  project_image_absolute_url: {  }
+  project_plan_schedule: {  }
   rendered_item: {  }
   reverse_entity_references: {  }
+  search_api_exclude_apartments_from_index: {  }
 tracker_settings:
   default:
     indexing_order: fifo

--- a/public/modules/custom/asu_elastic/src/Plugin/search_api/processor/SearchApiExcludeItemsFromIndex.php
+++ b/public/modules/custom/asu_elastic/src/Plugin/search_api/processor/SearchApiExcludeItemsFromIndex.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\asu_elastic\Plugin\search_api\processor;
+
+use Drupal\search_api\Plugin\PluginFormTrait;
+use Drupal\search_api\Processor\ProcessorPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Excludes entities marked as 'excluded' from being indexes.
+ *
+ * @SearchApiProcessor(
+ *   id = "search_api_exclude_apartments_from_index",
+ *   label = @Translation("Search API Exclude Apartments From Index - Custom Processor"),
+ *   description = @Translation("Excludes not in project apartment indexed."),
+ *   stages = {
+ *     "alter_items" = -50
+ *   }
+ * )
+ */
+class SearchApiExcludeItemsFromIndex extends ProcessorPluginBase {
+
+  use PluginFormTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    /** @var static $processor */
+    $processor = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+
+    return $processor;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterIndexedItems(array &$items) {
+    /** @var \Drupal\search_api\Item\ItemInterface $item */
+    foreach ($items as $item_id => $item) {
+      /** @var \Drupal\asu_content\Entity\Apartment $apartment */
+      $apartment = $item->getOriginalObject()->getValue();
+
+      if (!$apartment->getProject()) {
+        unset($items[$item_id]);
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
### Description

Elastic search now index all apartments but it can be cause some problems. This new process will exclude all apartments which are not referenced any project

### How to test it

- You need production sql to test it
- make fresh
- login as admin
- index apartment search api index https://asuntotuotanto.docker.so/fi/admin/config/search/search-api/index/apartment
- open search api in browser e.g. http://localhost:9200/_search?size=6000&pretty=true
- cmd + f and search /8128
  - node/8128 should not be in that elastic search result
```
  "title" : "Kustinpolku 6 A0",
          "url" : "https://asuntotuotanto.docker.so/fi/asuntohaku/hitas/asunto-oy-helsingin-postipaketti-kustinpolku-6/a0",
          "uuid" : "1c0a70a0-4913-4776-99c3-f0535ac6c2a3",
```