### PR TITLE
Satt 54 haso fee latest changes

### DIFF
--- a/conf/cmi/core.entity_view_display.node.apartment.default.yml
+++ b/conf/cmi/core.entity_view_display.node.apartment.default.yml
@@ -68,7 +68,7 @@ content:
     label: inline
     settings: {  }
     third_party_settings: {  }
-    weight: 29
+    weight: 25
     region: content
   field_alteration_work:
     type: number_decimal
@@ -79,7 +79,7 @@ content:
       scale: 2
       prefix_suffix: true
     third_party_settings: {  }
-    weight: 64
+    weight: 42
     region: content
   field_apartment_attachments:
     type: file_default
@@ -87,7 +87,7 @@ content:
     settings:
       use_description_as_link_text: true
     third_party_settings: {  }
-    weight: 57
+    weight: 35
     region: content
   field_apartment_number:
     type: string
@@ -95,7 +95,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 2
+    weight: 1
     region: content
   field_apartment_state_of_sale:
     type: entity_reference_label
@@ -103,7 +103,7 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 58
+    weight: 36
     region: content
   field_apartment_structure:
     type: string
@@ -111,7 +111,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 6
+    weight: 5
     region: content
   field_application_url:
     type: link
@@ -123,21 +123,21 @@ content:
       rel: '0'
       target: '0'
     third_party_settings: {  }
-    weight: 30
+    weight: 26
     region: content
   field_balcony_description:
     type: basic_string
     label: inline
     settings: {  }
     third_party_settings: {  }
-    weight: 13
+    weight: 11
     region: content
   field_bathroom_appliances:
     type: basic_string
     label: inline
     settings: {  }
     third_party_settings: {  }
-    weight: 14
+    weight: 12
     region: content
   field_condition:
     type: entity_reference_label
@@ -145,7 +145,7 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 53
+    weight: 31
     region: content
   field_debt_free_sales_price:
     type: number_decimal
@@ -156,18 +156,7 @@ content:
       scale: 2
       prefix_suffix: true
     third_party_settings: {  }
-    weight: 20
-    region: content
-  field_financing_fee:
-    type: number_decimal
-    label: inline
-    settings:
-      thousand_separator: ''
-      decimal_separator: .
-      scale: 2
-      prefix_suffix: true
-    third_party_settings: {  }
-    weight: 21
+    weight: 18
     region: content
   field_floor:
     type: number_integer
@@ -176,7 +165,7 @@ content:
       thousand_separator: ''
       prefix_suffix: true
     third_party_settings: {  }
-    weight: 4
+    weight: 3
     region: content
   field_floor_max:
     type: number_integer
@@ -185,7 +174,7 @@ content:
       thousand_separator: ''
       prefix_suffix: true
     third_party_settings: {  }
-    weight: 5
+    weight: 4
     region: content
   field_floorplan:
     type: image
@@ -196,7 +185,7 @@ content:
       image_loading:
         attribute: lazy
     third_party_settings: {  }
-    weight: 59
+    weight: 37
     region: content
   field_has_apartment_sauna:
     type: boolean
@@ -206,7 +195,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 16
+    weight: 14
     region: content
   field_has_balcony:
     type: boolean
@@ -216,7 +205,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 12
+    weight: 10
     region: content
   field_has_terrace:
     type: boolean
@@ -226,7 +215,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 11
+    weight: 9
     region: content
   field_has_yard:
     type: boolean
@@ -236,7 +225,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 10
+    weight: 8
     region: content
   field_haso_fee:
     type: number_decimal
@@ -247,7 +236,7 @@ content:
       scale: 2
       prefix_suffix: true
     third_party_settings: {  }
-    weight: 66
+    weight: 44
     region: content
   field_housing_manager:
     type: string
@@ -280,7 +269,6 @@ content:
       layout: ''
       thumbnail_caption: ''
       cache: 0
-      current_view_mode: default
       background: false
       caption:
         title: '0'
@@ -298,20 +286,17 @@ content:
         variableWidth: '0'
       skin_arrows: ''
       skin_dots: ''
-      fx: ''
-      icon: ''
       view_mode: ''
       box_caption: ''
       box_caption_custom: ''
       box_media_style: ''
       box_style: ''
-      _uri: ''
-      breakpoints: {  }
-      sizes: ''
-      grid_header: ''
       use_theme_field: false
+      link: ''
+      loading: lazy
+      preload: false
     third_party_settings: {  }
-    weight: 53
+    weight: 32
     region: content
   field_index_adjusted_right_of_oc:
     type: number_decimal
@@ -322,14 +307,14 @@ content:
       scale: 2
       prefix_suffix: true
     third_party_settings: {  }
-    weight: 63
+    weight: 41
     region: content
   field_kitchen_appliances:
     type: basic_string
     label: inline
     settings: {  }
     third_party_settings: {  }
-    weight: 9
+    weight: 7
     region: content
   field_living_area:
     type: number_decimal
@@ -340,14 +325,14 @@ content:
       scale: 1
       prefix_suffix: false
     third_party_settings: {  }
-    weight: 3
+    weight: 2
     region: content
   field_loan_share:
     type: number_unformatted
     label: inline
     settings: {  }
     third_party_settings: {  }
-    weight: 31
+    weight: 27
     region: content
   field_maintenance_fee:
     type: number_decimal
@@ -358,14 +343,14 @@ content:
       scale: 2
       prefix_suffix: true
     third_party_settings: {  }
-    weight: 22
+    weight: 19
     region: content
   field_other_fees:
     type: basic_string
     label: inline
     settings: {  }
     third_party_settings: {  }
-    weight: 27
+    weight: 23
     region: content
   field_parking_fee:
     type: number_decimal
@@ -376,14 +361,14 @@ content:
       scale: 2
       prefix_suffix: true
     third_party_settings: {  }
-    weight: 25
+    weight: 22
     region: content
   field_parking_fee_explanation:
     type: basic_string
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 49
+    weight: 28
     region: content
   field_publish_on_etuovi:
     type: boolean
@@ -393,7 +378,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 54
+    weight: 33
     region: content
   field_publish_on_oikotie:
     type: boolean
@@ -403,7 +388,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 55
+    weight: 34
     region: content
   field_release_payment:
     type: number_decimal
@@ -414,7 +399,7 @@ content:
       scale: 2
       prefix_suffix: true
     third_party_settings: {  }
-    weight: 65
+    weight: 43
     region: content
   field_right_of_occupancy_deposit:
     type: number_decimal
@@ -425,7 +410,7 @@ content:
       scale: 2
       prefix_suffix: true
     third_party_settings: {  }
-    weight: 61
+    weight: 39
     region: content
   field_right_of_occupancy_fee:
     type: number_decimal
@@ -436,7 +421,7 @@ content:
       scale: 2
       prefix_suffix: true
     third_party_settings: {  }
-    weight: 60
+    weight: 38
     region: content
   field_right_of_occupancy_payment:
     type: number_decimal
@@ -447,7 +432,7 @@ content:
       scale: 2
       prefix_suffix: true
     third_party_settings: {  }
-    weight: 62
+    weight: 40
     region: content
   field_room_count:
     type: number_integer
@@ -456,7 +441,7 @@ content:
       thousand_separator: ''
       prefix_suffix: true
     third_party_settings: {  }
-    weight: 7
+    weight: 6
     region: content
   field_sales_price:
     type: number_decimal
@@ -467,14 +452,14 @@ content:
       scale: 2
       prefix_suffix: true
     third_party_settings: {  }
-    weight: 19
+    weight: 17
     region: content
   field_services_description:
     type: basic_string
     label: inline
     settings: {  }
     third_party_settings: {  }
-    weight: 28
+    weight: 24
     region: content
   field_showing_time:
     type: datetime_default
@@ -483,7 +468,7 @@ content:
       timezone_override: ''
       format_type: medium
     third_party_settings: {  }
-    weight: 18
+    weight: 16
     region: content
   field_stock_end_number:
     type: number_integer
@@ -492,7 +477,7 @@ content:
       thousand_separator: ''
       prefix_suffix: true
     third_party_settings: {  }
-    weight: 52
+    weight: 30
     region: content
   field_stock_start_number:
     type: number_integer
@@ -501,21 +486,21 @@ content:
       thousand_separator: ''
       prefix_suffix: true
     third_party_settings: {  }
-    weight: 51
+    weight: 29
     region: content
   field_storage_description:
     type: basic_string
     label: inline
     settings: {  }
     third_party_settings: {  }
-    weight: 15
+    weight: 13
     region: content
   field_view_description:
     type: basic_string
     label: inline
     settings: {  }
     third_party_settings: {  }
-    weight: 17
+    weight: 15
     region: content
   field_water_fee:
     type: number_decimal
@@ -526,14 +511,14 @@ content:
       scale: 2
       prefix_suffix: true
     third_party_settings: {  }
-    weight: 23
+    weight: 20
     region: content
   field_water_fee_explanation:
     type: basic_string
     label: inline
     settings: {  }
     third_party_settings: {  }
-    weight: 24
+    weight: 21
     region: content
   links:
     settings: {  }
@@ -558,6 +543,7 @@ hidden:
   field_apartment_holding_type: true
   field_apartment_images: true
   field_apartment_url: true
+  field_financing_fee: true
   field_housing_company_fee: true
   field_price_m2: true
   field_project_url: true

--- a/conf/cmi/search_api.index.apartment_listing.yml
+++ b/conf/cmi/search_api.index.apartment_listing.yml
@@ -3,11 +3,11 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.storage.node.field_haso_fee
     - field.storage.node.field_floor_max
     - field.storage.node.field_apartment_number
     - field.storage.node.field_apartment_state_of_sale
     - field.storage.node.field_apartment_structure
-    - field.storage.node.field_right_of_occupancy_payment
     - field.storage.node.field_has_balcony
     - field.storage.node.field_debt_free_sales_price
     - field.storage.node.field_floor
@@ -23,6 +23,7 @@ dependencies:
     - node
     - computed_field_plugin
     - search_api
+    - helfi_react_search
 id: apartment_listing
 name: 'Apartment listing'
 description: ''
@@ -132,6 +133,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_has_yard
+  haso_fee:
+    label: 'Alkuperäinen asumisoikeusmaksu'
+    datasource_id: 'entity:node'
+    property_path: field_haso_fee
+    type: cent
+    dependencies:
+      config:
+        - field.storage.node.field_haso_fee
   housing_company_fee:
     label: 'Housing company fee'
     datasource_id: 'entity:node'
@@ -280,14 +289,6 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_release_payment
-  right_of_occupancy_payment:
-    label: Asumisoikeusmaksu
-    datasource_id: 'entity:node'
-    property_path: field_right_of_occupancy_payment
-    type: cent
-    dependencies:
-      config:
-        - field.storage.node.field_right_of_occupancy_payment
   room_count:
     label: 'Number of rooms'
     datasource_id: 'entity:node'
@@ -340,6 +341,8 @@ datasource_settings:
 processor_settings:
   add_url: {  }
   aggregated_field: {  }
+  custom_value: {  }
+  district_image_absolute_url: {  }
   entity_type: {  }
   html_filter:
     weights:
@@ -351,6 +354,9 @@ processor_settings:
     alt: true
     tags: {  }
   language_with_fallback: {  }
+  project_execution_schedule: {  }
+  project_image_absolute_url: {  }
+  project_plan_schedule: {  }
   rendered_item: {  }
   reverse_entity_references: {  }
 tracker_settings:

--- a/conf/cmi/views.view.project_apartments_listing.yml
+++ b/conf/cmi/views.view.project_apartments_listing.yml
@@ -7,10 +7,10 @@ dependencies:
     - field.storage.node.field_apartment_structure
     - field.storage.node.field_debt_free_sales_price
     - field.storage.node.field_floor
+    - field.storage.node.field_haso_fee
     - field.storage.node.field_living_area
     - field.storage.node.field_ownership_type
     - field.storage.node.field_release_payment
-    - field.storage.node.field_right_of_occupancy_payment
     - node.type.apartment
   module:
     - node
@@ -419,72 +419,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        field_right_of_occupancy_payment:
-          id: field_right_of_occupancy_payment
-          table: node__field_right_of_occupancy_payment
-          field: field_right_of_occupancy_payment
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: field
-          label: Asumisoikeusmaksu
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: true
-          empty_zero: true
-          hide_alter_empty: true
-          click_sort_column: value
-          type: number_decimal
-          settings:
-            thousand_separator: ' '
-            decimal_separator: ','
-            scale: 2
-            prefix_suffix: false
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
         nid:
           id: nid
           table: node_field_data
@@ -605,6 +539,72 @@ display:
           settings:
             link: false
           group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_haso_fee:
+          id: field_haso_fee
+          table: node__field_haso_fee
+          field: field_haso_fee
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: 'Alkuperäinen asumisoikeusmaksu'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_decimal
+          settings:
+            thousand_separator: ''
+            decimal_separator: .
+            scale: 2
+            prefix_suffix: true
+          group_column: value
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -987,10 +987,10 @@ display:
         - 'config:field.storage.node.field_apartment_structure'
         - 'config:field.storage.node.field_debt_free_sales_price'
         - 'config:field.storage.node.field_floor'
+        - 'config:field.storage.node.field_haso_fee'
         - 'config:field.storage.node.field_living_area'
         - 'config:field.storage.node.field_ownership_type'
         - 'config:field.storage.node.field_release_payment'
-        - 'config:field.storage.node.field_right_of_occupancy_payment'
   project_apartments_listing_block:
     id: project_apartments_listing_block
     display_title: 'Project Apartments Listing'
@@ -1016,7 +1016,7 @@ display:
         - 'config:field.storage.node.field_apartment_structure'
         - 'config:field.storage.node.field_debt_free_sales_price'
         - 'config:field.storage.node.field_floor'
+        - 'config:field.storage.node.field_haso_fee'
         - 'config:field.storage.node.field_living_area'
         - 'config:field.storage.node.field_ownership_type'
         - 'config:field.storage.node.field_release_payment'
-        - 'config:field.storage.node.field_right_of_occupancy_payment'

--- a/public/modules/custom/asu_content/asu_content.module
+++ b/public/modules/custom/asu_content/asu_content.module
@@ -199,6 +199,7 @@ function asu_content_hide_fields_in_hitas(&$form) {
     'field_right_of_occupancy_fee',
     'field_index_adjusted_right_of_oc',
     'field_right_of_occupancy_deposit',
+    'field_release_payment',
   ];
 
   foreach ($hide_fields as $field) {

--- a/public/modules/custom/asu_content/asu_content.module
+++ b/public/modules/custom/asu_content/asu_content.module
@@ -38,6 +38,7 @@ function asu_content_form_node_form_alter(&$form, $form_state) {
   asu_content_hide_node_title($form);
   asu_content_show_computed_fields($form, $form_state);
   asu_content_project_add_archived_handling($form, $form_state);
+  asu_content_hide_field_in_apartment_edit($form, $form_state);
 }
 
 /**
@@ -108,6 +109,101 @@ function asu_content_show_computed_fields(&$form, $form_state) {
           $value . ' €/m²'
         );
       }
+    }
+  }
+}
+
+/**
+ * Hide price fields which is not used in HASO.
+ */
+function asu_content_hide_field_in_apartment_edit(&$form, $form_state) {
+  if ($ownership_type = asu_content_get_ownershiptype()) {
+    if (strtolower($ownership_type) == 'haso') {
+      asu_content_hide_fields_in_haso($form);
+    }
+
+    if (strtolower($ownership_type) == 'hitas') {
+      asu_content_hide_fields_in_hitas($form);
+    }
+  }
+
+}
+
+/**
+ * Get HASO / HITAS edit form ownership type from url.
+ */
+function asu_content_get_ownershiptype() {
+  $ownership_type = NULL;
+  $node = \Drupal::routeMatch()->getParameter('node');
+
+  if ($node instanceof Apartment || $node instanceof Project) {
+    if ($node instanceof Apartment) {
+      $project = $node->getProject();
+    } else {
+      $project = $node;
+    }
+
+    $ownership_type = $project->get('field_ownership_type')->referencedEntities()[0]->getName() ?? NULL;
+  }
+
+  return $ownership_type;
+}
+
+/**
+ * Hide fields in HASO / HITAS apartment edit form.
+ */
+function asu_content_inline_entity_form_entity_form_alter(&$entity_form, &$form_state) {
+  if ($entity_form['#entity_type'] == 'node' && $entity_form['#bundle'] == 'apartment') {
+    $ownership_type = asu_content_get_ownershiptype();
+
+    if ($ownership_type && strtolower($ownership_type) == 'haso') {
+      asu_content_hide_fields_in_haso($entity_form);
+    }
+
+    if ($ownership_type && strtolower($ownership_type) == 'hitas') {
+      asu_content_hide_fields_in_hitas($entity_form);
+    }
+  }
+}
+
+/**
+ * Hide fields in HASO apartment edit form.
+ */
+function asu_content_hide_fields_in_haso(&$form) {
+  $hide_fields = [
+    'field_debt_free_sales_price',
+    'field_sales_price',
+    'field_maintenance_fee',
+    'field_financing_fee',
+    'field_debt_free_sales_price',
+    'field_water_fee',
+    'field_water_fee_explanation',
+    'field_loan_share',
+  ];
+
+  foreach ($hide_fields as $field) {
+    if (isset($form[$field])) {
+      $form[$field]['#access'] = FALSE;
+    }
+  }
+}
+
+/**
+ * Hide fields in HITAS apartment edit form.
+ */
+function asu_content_hide_fields_in_hitas(&$form) {
+  $hide_fields = [
+    'field_haso_fee',
+    'field_right_of_occupancy_payment',
+    'field_index_adjusted_right_of_oc',
+    'field_right_of_occupancy_fee',
+    'field_index_adjusted_right_of_oc',
+    'field_right_of_occupancy_deposit',
+  ];
+
+  foreach ($hide_fields as $field) {
+    if (isset($form[$field])) {
+      $form[$field]['#access'] = FALSE;
     }
   }
 }

--- a/public/modules/custom/asu_content/asu_content.module
+++ b/public/modules/custom/asu_content/asu_content.module
@@ -139,7 +139,8 @@ function asu_content_get_ownershiptype() {
   if ($node instanceof Apartment || $node instanceof Project) {
     if ($node instanceof Apartment) {
       $project = $node->getProject();
-    } else {
+    }
+    else {
       $project = $node;
     }
 

--- a/public/modules/custom/asu_content/src/BatchService.php
+++ b/public/modules/custom/asu_content/src/BatchService.php
@@ -40,7 +40,7 @@ class BatchService {
 
   public static function processConvertOccupancyPayment($id, $nodes, &$context) {
     foreach ($nodes as $node) {
-      usleep(10);
+      usleep(100);
       $entityService = \Drupal::entityTypeManager();
       /** @var \Drupal\asu_content\Entity\Project $project */
       $project = $entityService->getStorage('node')->load($node->nid);

--- a/public/modules/custom/asu_content/src/BatchService.php
+++ b/public/modules/custom/asu_content/src/BatchService.php
@@ -2,9 +2,6 @@
 
 namespace Drupal\asu_content;
 
-use Drupal\asu_content\Entity\Apartment;
-use Drupal\asu_content\Entity\Project;
-
 /**
  * Batch service to update node aliases.
  */
@@ -38,6 +35,9 @@ class BatchService {
     }
   }
 
+  /**
+   * Batch process to process occupancy Ppayment.
+   */
   public static function processConvertOccupancyPayment($id, $nodes, &$context) {
     foreach ($nodes as $node) {
       usleep(100);

--- a/public/modules/custom/asu_content/src/BatchService.php
+++ b/public/modules/custom/asu_content/src/BatchService.php
@@ -2,6 +2,9 @@
 
 namespace Drupal\asu_content;
 
+use Drupal\asu_content\Entity\Apartment;
+use Drupal\asu_content\Entity\Project;
+
 /**
  * Batch service to update node aliases.
  */
@@ -27,6 +30,56 @@ class BatchService {
         /** @var \Drupal\node\Entity $entity */
         $entity->path->pathauto = 1;
         $entity->save();
+        $context['results'][] = $id;
+        $context['message'] = t('processing "@id"',
+          ['@id' => $id]
+        );
+      }
+    }
+  }
+
+  public static function processConvertOccupancyPayment($id, $nodes, &$context) {
+    foreach ($nodes as $node) {
+      usleep(10);
+      $entityService = \Drupal::entityTypeManager();
+      /** @var \Drupal\asu_content\Entity\Project $project */
+      $project = $entityService->getStorage('node')->load($node->nid);
+
+      if ($project) {
+        // Get project apartment entities.
+        /** @var \Drupal\asu_content\Entity\Apartment $apartment */
+        foreach ($project->getApartmentEntities() as $apartment) {
+          $field_alteration_work = NULL;
+          $field_index_adjusted_right_of_oc = NULL;
+
+          if (!$apartment->get('field_alteration_work')->isEmpty()) {
+            $field_alteration_work = $apartment->get('field_alteration_work')->first()->getValue()['value'];
+
+            if ($field_alteration_work == '0.00') {
+              $field_alteration_work = NULL;
+            }
+          }
+
+          if (!$apartment->get('field_index_adjusted_right_of_oc')->isEmpty()) {
+            $field_index_adjusted_right_of_oc = $apartment->get('field_index_adjusted_right_of_oc')->first()->getValue()['value'];
+
+            if ($field_index_adjusted_right_of_oc == '0.00') {
+              $field_index_adjusted_right_of_oc = NULL;
+            }
+          }
+
+          if (empty($field_alteration_work) && empty($field_index_adjusted_right_of_oc)) {
+            $field_right_of_occupancy_payment = NULL;
+            if (!$apartment->get('field_right_of_occupancy_payment')->isEmpty()) {
+              $field_right_of_occupancy_payment = $apartment->get('field_right_of_occupancy_payment')->first()->getValue()['value'];
+            }
+
+            $apartment->set('field_right_of_occupancy_payment', NULL);
+            $apartment->set('field_haso_fee', $field_right_of_occupancy_payment);
+            $apartment->save();
+          }
+        }
+
         $context['results'][] = $id;
         $context['message'] = t('processing "@id"',
           ['@id' => $id]

--- a/public/modules/custom/asu_content/src/Commands/AsuContentDrushCommands.php
+++ b/public/modules/custom/asu_content/src/Commands/AsuContentDrushCommands.php
@@ -120,7 +120,7 @@ class AsuContentDrushCommands extends DrushCommands {
   #[CLI\Command(name: 'asu_content:convertOccupancyToHasofee', aliases: ['ac-oth'])]
   #[CLI\Usage(name: 'drush ac-oth', description: 'Convert right_of_occupancy_payment to haso_fee field.')]
   public function convertOccupancyToHasofee() {
-    $projects = \Drupal::entityTypeManager()
+    $projects = $this->entityTypeManager
       ->getStorage('node')
       ->loadByProperties([
         'type' => 'project',

--- a/public/modules/custom/asu_content/src/Commands/AsuContentDrushCommands.php
+++ b/public/modules/custom/asu_content/src/Commands/AsuContentDrushCommands.php
@@ -112,4 +112,69 @@ class AsuContentDrushCommands extends DrushCommands {
     }
   }
 
+  /**
+   * Convert right_of_occupancy_payment to haso_fee field.
+   *
+   * @command asu_content:occupancy-to-hasofee
+   */
+  #[CLI\Command(name: 'asu_content:convertOccupancyToHasofee', aliases: ['ac-oth'])]
+  #[CLI\Usage(name: 'drush ac-oth', description: 'Convert right_of_occupancy_payment to haso_fee field.')]
+  public function convertOccupancyToHasofee() {
+    $projects = \Drupal::entityTypeManager()
+      ->getStorage('node')
+      ->loadByProperties([
+        'type' => 'project',
+        'field_ownership_type' => 14,
+      ]);
+
+    // Create the operations array for the batch.
+    $operations = [];
+    $num_operations = 0;
+    $batch_id = 1;
+
+    $query = $this->connection->select('node', 'n');
+    $query->leftJoin('node__field_ownership_type', 'o', 'n.nid = o.entity_id');
+    $query->condition('n.type', 'project');
+    $query->condition('o.field_ownership_type_target_id', 14);
+    $query->fields('n', ['nid']);
+    $results_count = count($projects);
+
+    if ($results_count > 0) {
+      for ($i = 0; $i < $results_count; $i = $i + 10) {
+        $query->range($i, 10);
+        $results = $query->execute()->fetchAll();
+
+        // Prepare the operation. Here we could do other operations on nodes.
+        $this->output()->writeln("Preparing batch: " . $batch_id);
+
+        $operations[] = [
+          '\Drupal\asu_content\BatchService::processConvertOccupancyPayment',
+          [
+            $batch_id,
+            $results,
+          ],
+        ];
+
+        $batch_id++;
+        $num_operations++;
+      }
+
+      // Create the batch.
+      $batch = [
+        'title' => $this->t('Updating @num node aliases', ['@num' => $num_operations]),
+        'operations' => $operations,
+        'finished' => '\Drupal\asu_content\BatchService::processContentAliasUpdateFinished',
+      ];
+
+      // Add batch operations as new batch sets.
+      batch_set($batch);
+
+      // Process the batch sets.
+      drush_backend_batch_process();
+
+      // Show some information.
+      $this->logger()->notice("Batch operations end.");
+    }
+  }
+
 }

--- a/public/modules/custom/asu_rest/src/Plugin/rest/resource/ElasticSearch.php
+++ b/public/modules/custom/asu_rest/src/Plugin/rest/resource/ElasticSearch.php
@@ -153,13 +153,13 @@ class ElasticSearch extends ResourceBase {
         'project_url',
         'project_uuid',
         'release_payment',
-        'right_of_occupancy_payment',
         'title',
         'url',
         'uuid',
         'sales_price',
         'room_count',
         'sales_price',
+        'haso_fee',
       ];
 
       foreach ($resultItems as $item) {
@@ -295,7 +295,7 @@ class ElasticSearch extends ResourceBase {
 
     if ($value = $parameters->get('price')) {
       $field = strtolower($parameters->get('project_ownership_type')) == 'hitas' ?
-        'debt_free_sales_price' : 'right_of_occupancy_payment';
+        'debt_free_sales_price' : 'field_haso_fee';
       $baseConditionGroup->addCondition($field, $value, '<');
     }
   }

--- a/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
@@ -95,7 +95,6 @@
 {% set release_payment = content.field_release_payment.0 %}
 {% set debt_free_sales_price = content.field_debt_free_sales_price.0 %}
 {% set apartment_number = content.field_apartment_number.0 %}
-{% set financing_fee = content.field_financing_fee.0 %}
 {% set maintenance_fee = content.field_maintenance_fee.0 %}
 {% set right_of_occupancy_fee = content.field_right_of_occupancy_fee.0 %}
 {% set right_of_occupancy_payment = content.field_right_of_occupancy_payment.0 %}
@@ -325,7 +324,6 @@
               and (apartment_structure|render == '')
               and (right_of_occupancy_fee|render == '0.00€')
               and (maintenance_fee|render == '0.00€ / kk')
-              and (financing_fee|render == '0.00€ / month')
               and (energy_class|render == null)
               and (accessibility|render == null)
               and (site_owner|render == null)
@@ -458,14 +456,6 @@
 							<p>
 								<span>{% trans %}Maintenance fee{% endtrans %}</span>
 								<span>{{ maintenance_fee }}</span>
-							</p>
-						</li>
-					{% endif %}
-          {% if financing_fee|render and financing_fee|render != '0.00€ / month' %}
-						<li class="apartment__details-item">
-							<p>
-								<span>{% trans %}Financing fee{% endtrans %}</span>
-								<span>{{ financing_fee }}</span>
 							</p>
 						</li>
 					{% endif %}

--- a/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
@@ -93,6 +93,7 @@
 {% set adjusted_price = content.field_index_adjusted_right_of_oc.0 %}
 {% set alteration_price = content.field_alteration_work.0 %}
 {% set release_payment = content.field_release_payment.0 %}
+{% set loan_share = content.field_loan_share.0 %}
 {% set debt_free_sales_price = content.field_debt_free_sales_price.0 %}
 {% set apartment_number = content.field_apartment_number.0 %}
 {% set maintenance_fee = content.field_maintenance_fee.0 %}
@@ -389,6 +390,14 @@
               <p>
                 <span>{% trans %}Original HASO Fee{% endtrans %}</span>
                 <span>{{ haso_fee }}</span>
+              </p>
+            </li>
+          {% endif %}
+          {% if loan_share|render and loan_share|render != '0,00€' and loan_share|render != null %}
+            <li class="apartment__details-item">
+              <p>
+                <span>{% trans %}Share of housing company loan{% endtrans %}</span>
+                <span>{{ loan_share }}€</span>
               </p>
             </li>
           {% endif %}

--- a/public/themes/custom/asuntotuotanto/templates/views/project/views-view-table--project-apartments-listing.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/views/project/views-view-table--project-apartments-listing.html.twig
@@ -228,14 +228,14 @@
         {% set apartment_structure = row.columns.field_apartment_structure.content.0.field_output['#markup']|striptags|trim	 %}
         {% set debt_free_sales_price = row.columns.field_debt_free_sales_price.content.0.field_output['#markup']|striptags|trim %}
         {% set release_payment_price = row.columns.field_release_payment.content.0.field_output['#markup']|striptags|trim %}
+        {% set haso_fee = row.columns.field_haso_fee.content.0.field_output['#markup']|striptags|trim %}
         {% set floor = row.columns.field_floor.content.0.field_output['#markup']|striptags|trim %}
         {% set living_area_size = row.columns.field_living_area.content.0.field_output['#markup']|striptags|trim %}
         {% set nid = row.columns.nid.content.0.field_output['#markup']|striptags|trim %}
         {% set price_title = 'Debt-free sales price'|t %}
 
-        {% if debt_free_sales_price == null or debt_free_sales_price == '' or debt_free_sales_price == 0 or debt_free_sales_price == '0,00' %}
-          {% set debt_free_sales_price = row.columns.field_right_of_occupancy_payment.content.0.field_output['#markup']|striptags|trim %}
-          {% set price_title = 'Right of occupancy payment'|t %}
+        {% if haso_fee is not empty and haso_fee > 0 %}
+          {% set debt_free_sales_price = haso_fee %}
         {% endif %}
 
         {% if release_payment_price is not empty and release_payment_price > 0 %}


### PR DESCRIPTION
### Description

Lots of minor changes on prices fields

### What is changed or what to test

- make fresh
- make shell and run drush ac-oth ***notice***
  *** you can check before running the command how many lines are in database on **field_right_of_occupancy_payment** table and **node__field_haso_fee** and then after you have run the command. then you see the difference

- login as admin
- rebuild tracking information and re-index apartment listing search api https://asuntotuotanto.docker.so/fi/admin/config/search/search-api/index/apartment_listing


#### HITAS
- https://asuntotuotanto.docker.so/fi/asuntohaku/hitas
- open some hitas apartment page
  - check that there is Share of housing company loan value is that if filled so open edit apartment and check
![CleanShot 2024-05-17 at 15 13 01@2x](https://github.com/City-of-Helsinki/drupal-asuntotuotanto/assets/5573746/7f31c30a-2cd1-4e61-9ba7-29870b22c79c)
- Also open hitas project on edit 
  - click apartment tab
  - open some apartment edit mode
  - check that excel sheet and check that those fields are hidden which should be hidden
- check same on editing apartment node


#### HASO
- go https://asuntotuotanto.docker.so/fi/asuntohaku/haso and open inspect mode and network tab
  - check elasticsearch page and see that **haso_fee** is giving some data
  - also **right_of_occupancy_payment** is removed from elastic
![CleanShot 2024-05-17 at 15 19 08@2x](https://github.com/City-of-Helsinki/drupal-asuntotuotanto/assets/5573746/33a7d2bf-da18-4b4e-bc12-3c243f8d7113)
- open some haso apartment page
  - rahoitusvastike field is now taken off
- open that aparment edit mode and check also that those fields are hidden on HASO side what is marked on excel sheet
- also open haso project and do the same on apartment tab  
