### PR TITLE
SATT-61: Reserved apartment contact email validation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,8 @@ services:
       # XDEBUG_ENABLE: "true"
       # DOCKERHOST: host.docker.internal
       # XDEBUG_CONFIG: "remote_port=9001 remote_host=host.docker.internal remote_connect_back=0"
-      PHP_SENDMAIL_PATH: /usr/sbin/sendmail -S stonehenge:1025
+      # PHP_IDE_CONFIG: "${PHP_IDE_CONFIG:-serverName=${DRUPAL_HOSTNAME}}"
+      PHP_SENDMAIL_PATH: /usr/sbin/sendmail -S host.docker.internal:1025 -t
 
       # permission issues.
       DTT_BASE_URL: "http://app:8080"

--- a/public/modules/custom/asu_application/src/Form/ReservedApartmentContactForm.php
+++ b/public/modules/custom/asu_application/src/Form/ReservedApartmentContactForm.php
@@ -143,10 +143,23 @@ class ReservedApartmentContactForm extends FormBase {
     $project_id = $this->requestStack->getCurrentRequest()->get('project') ?? NULL;
     $values = $form_state->cleanValues()->getValues();
     $body = $this->convertMessage($values);
+    $email_to = $values['field_contact_person'];
+
+    $user = $this->entityTypeManager->getStorage('user')
+      ->loadByProperties([
+        'mail' => $values['field_contact_person'],
+        'type' => 'sales',
+      ]);
+    $user = reset($user);
+
+    // If salesperson not exist use default email address.
+    if (!$user) {
+      $email_to = getenv('DRUPAL_DEFAULT_FORM_EMAIL');
+    }
 
     $module = 'asu_application';
     $key = 'apply_for_free_apartment';
-    $to = $values['field_contact_person'];
+    $to = $email_to;
     $langcode = 'fi';
     $send = TRUE;
     $subject = 'Yhteydenottopyyntö vapaaseen huoneistoon' . $values['field_apartment_information'];


### PR DESCRIPTION
### Description

Reserved apartment contact form salesperson email validation


### How to test

- add **DRUPAL_DEFAULT_FORM_EMAIL** variable to docker-compose.yml
- make fresh
- login as admin
- index apartment listing search api index
- search and go apply for free apartment form
  - I used https://asuntotuotanto.docker.so/fi/contact/apply_for_free_apartment?apartment=A5&project=529
- Fill form and check that everything works https://mailpit.docker.so/
  - Easiest way to test default email address is edit code on ReservedApartmentContactForm.php 