### PR TITLE
SATT-54: Latest HASO fee field related changes

### DIFF
--- a/public/modules/custom/asu_content/src/BatchService.php
+++ b/public/modules/custom/asu_content/src/BatchService.php
@@ -124,10 +124,31 @@ class BatchService {
               // if release_payment field is empty.
               $apartment->set('field_release_payment', $field_right_of_occupancy_payment);
             }
+            // Check if release_payment field empty.
+            if ($apartment->get('field_haso_fee')->isEmpty()) {
+              // Set HASO fee value to release_payment field
+              // if release_payment field is empty.
+              $apartment->set('field_release_payment', $field_right_of_occupancy_payment);
+            }
+          }
+
+          // Case where haso fee & release payment is empty.
+          if ($apartment->get('field_haso_fee')->isEmpty() &&
+            $apartment->get('field_release_payment')->isEmpty() &&
+            !empty($field_alteration_work) &&
+            !empty($field_index_adjusted_right_of_oc)
+          ) {
+            // Get Haso fee field value if exist.
+            $apartment->set('field_release_payment', $field_index_adjusted_right_of_oc + $field_alteration_work);
+            $field_right_of_occupancy_payment = $field_index_adjusted_right_of_oc - floatval($apartment->get('field_right_of_occupancy_payment')->first()->getValue()['value']);
           }
 
           // Set a new HASO fee field value.
-          $apartment->set('field_haso_fee', $field_right_of_occupancy_payment);
+          if ($apartment->get('field_haso_fee')->isEmpty() &&
+            !$apartment->get('field_release_payment')->isEmpty())
+          {
+            $apartment->set('field_haso_fee', $field_right_of_occupancy_payment);
+          }
           $apartment->save();
         }
 

--- a/public/modules/custom/asu_content/src/BatchService.php
+++ b/public/modules/custom/asu_content/src/BatchService.php
@@ -105,8 +105,9 @@ class BatchService {
           // should be in haso fee field.
           if ($apartment->get('field_haso_fee')->isEmpty() &&
             !$apartment->get('field_right_of_occupancy_payment')->isEmpty() &&
-            !empty($field_alteration_work) &&
-            !empty($field_index_adjusted_right_of_oc)
+            !$apartment->get('field_release_payment')->isEmpty() &&
+            (!empty($field_alteration_work) ||
+            !empty($field_index_adjusted_right_of_oc))
           ) {
             $occupancy_payment = floatval($apartment->get('field_right_of_occupancy_payment')->first()->getValue()['value']);
             $field_release_payment = $apartment->get('field_release_payment')->first()->getValue()['value'];

--- a/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
+++ b/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
@@ -380,9 +380,7 @@ function asuntotuotanto_form_alter(&$form, &$form_state, $form_id) {
  * Implements hook_preprocess_node().
  */
 function asuntotuotanto_preprocess_node(&$variables) {
-
   $date_formatter = \Drupal::service('date.formatter');
-
   $node = $variables['node'];
   $bundle = $node->getType();
 

--- a/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
@@ -377,7 +377,7 @@
 							</p>
 						</li>
 					{% endif %}
-					{% if sales_price|render and sales_price|render != '0,00€' and sales_price|render != null %}
+					{% if ownership_type|lower == 'hitas' and sales_price|render and sales_price|render != '0,00€' and sales_price|render != null %}
 						<li class="apartment__details-item">
 							<p>
 								<span>{% trans %}Sales price{% endtrans %}</span>
@@ -385,15 +385,7 @@
 							</p>
 						</li>
 					{% endif %}
-          {% if haso_fee|render and haso_fee|render != '0,00€' and haso_fee|render != null %}
-            <li class="apartment__details-item">
-              <p>
-                <span>{% trans %}Original HASO Fee{% endtrans %}</span>
-                <span>{{ haso_fee }}</span>
-              </p>
-            </li>
-          {% endif %}
-          {% if loan_share|render and loan_share|render != '0,00€' and loan_share|render != null %}
+          {% if ownership_type|lower == 'hitas' and loan_share|render and loan_share['#markup'] != '0.00' and loan_share|render != null %}
             <li class="apartment__details-item">
               <p>
                 <span>{% trans %}Share of housing company loan{% endtrans %}</span>
@@ -401,7 +393,7 @@
               </p>
             </li>
           {% endif %}
-					{% if debt_free_sales_price|render and debt_free_sales_price|render != '0,00€' and debt_free_sales_price|render != null %}
+					{% if ownership_type|lower == 'hitas' and debt_free_sales_price|render and debt_free_sales_price|render != '0,00€' and debt_free_sales_price|render != null %}
 						<li class="apartment__details-item">
 							<p>
 								<span>{% trans %}Debt free sales price{% endtrans %}</span>
@@ -409,13 +401,21 @@
 							</p>
 						</li>
 					{% endif %}
-          {% if release_payment|render and release_payment|render != '0,00€' and release_payment|render != null %}
+          {% if ownership_type|lower == 'haso' and release_payment|render and release_payment|render != '0,00€' and release_payment|render != null %}
             <li class="apartment__details-item">
               <p>
                 <span>{% trans %}Release payment{% endtrans %}</span>
                 <span>{{ release_payment }}</span>
               </p>
               <ul class="apartment__details-list sub__details-list">
+                {% if haso_fee|render and haso_fee|render != '0,00€' and haso_fee|render != null %}
+                  <li class="apartment__details-item">
+                  <p>
+                      <span>{% trans %}Original HASO Fee{% endtrans %}</span>
+                      <span>{{ haso_fee }}</span>
+                    </p>
+                  </li>
+                {% endif %}
                 {% if right_of_occupancy_payment|render and right_of_occupancy_payment|render != '0,00€' and right_of_occupancy_payment|render != null %}
                   <li class="apartment__details-item">
                     <p>
@@ -452,7 +452,7 @@
               </li>
             {% endif %}
           {% endif %}
-          {% if right_of_occupancy_fee|render and right_of_occupancy_fee|render != '0.00€' %}
+          {% if ownership_type|lower == 'haso' and right_of_occupancy_fee|render and right_of_occupancy_fee|render != '0.00€' %}
 						<li class="apartment__details-item">
 							<p>
 								<span>{% trans %}Right of occupancy fee{% endtrans %}</span>
@@ -460,7 +460,7 @@
 							</p>
 						</li>
 					{% endif %}
-          {% if maintenance_fee|render and maintenance_fee|render != '0.00€ / kk' %}
+          {% if ownership_type|lower == 'hitas' and maintenance_fee|render and maintenance_fee|render != '0.00€ / kk' %}
 						<li class="apartment__details-item">
 							<p>
 								<span>{% trans %}Maintenance fee{% endtrans %}</span>
@@ -492,7 +492,7 @@
 							</p>
 						</li>
 					{% endif %}
-          {% if field_alteration_work|render %}
+          {% if ownership_type|lower == 'hitas' and field_alteration_work|render %}
             <li class="apartment__details-item">
               <p>
                 <span>{% trans %}Alteration work{% endtrans %}</span>
@@ -500,7 +500,7 @@
               </p>
             </li>
           {% endif %}
-          {% if field_water_fee|render and field_water_fee|render != '0.00' %}
+          {% if ownership_type|lower == 'hitas' and field_water_fee|render and field_water_fee|render != '0.00' %}
             <li class="apartment__details-item">
               <p>
                 <span>{% trans %}Water fee{% endtrans %}</span>
@@ -508,7 +508,7 @@
               </p>
             </li>
           {% endif %}
-          {% if field_water_fee_explanation|render %}
+          {% if ownership_type|lower == 'hitas' and field_water_fee_explanation|render %}
             <li class="apartment__details-item">
               <p>
                 <span>{% trans %}Water fee explanation{% endtrans %}</span>


### PR DESCRIPTION
### Description

Latest Haso fee field related changes and fixes
- better field conditions on hitas and haso fields
- more functionality to fill a new HASO fee field

### How to test

- make fresh
- make shell
- drush ac-oth
- login as admin to site
- rebuild tracking information and re-index apartment listing search api index https://asuntotuotanto.docker.so/fi/admin/config/search/search-api
- now go Haso listing page https://asuntotuotanto.docker.so/fi/asuntohaku/haso
- Open ramdomly apartments at different projects pages to tabs
  - click edit and open Hintatiedot
- Every apartment should be
  - Luovutushinta and Alkuperäinen asumisoikeusmaksu
    - Luovutushinta and Alkuperäinen asumisoikeusmaksu **should** be same values if Indeksitarkistettu asumisoikeusmaksu and Tilatut muutostyöt is empty
    - Luovutushinta and Alkuperäinen asumisoikeusmaksu **should't** be same if  if Indeksitarkistettu asumisoikeusmaksu and Tilatut muutostyöt has values 
   
** You can always compare values to testing site where values are before script is runned https://nginx-asuntotuotanto-test.agw.arodevtest.hel.fi/fi