### PR TITLE
SATT-60: React component 1.4.1 which fix listing prices

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -171,9 +171,9 @@
             "type": "package",
             "package": {
                 "name": "asuntomyynti/react",
-                "version": "1.4.0",
+                "version": "1.4.1",
                 "dist": {
-                    "url": "https://github.com/City-of-Helsinki/asuntomyynti-react/releases/download/v.1.4.0/asuntomyynti-react-1.4.0.zip",
+                    "url": "https://github.com/City-of-Helsinki/asuntomyynti-react/releases/download/v.1.4.1/asuntomyynti-react-1.4.1.zip",
                     "type": "zip"
                 }
             }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a4c7d12c808450ac8b1adf9430ddd0e",
+    "content-hash": "d460c3127887bc9eecb7a22c29958a53",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -64,10 +64,10 @@
         },
         {
             "name": "asuntomyynti/react",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/City-of-Helsinki/asuntomyynti-react/releases/download/v.1.4.0/asuntomyynti-react-1.4.0.zip"
+                "url": "https://github.com/City-of-Helsinki/asuntomyynti-react/releases/download/v.1.4.1/asuntomyynti-react-1.4.1.zip"
             },
             "type": "library"
         },


### PR DESCRIPTION
### Description

React component update 1.4.1 which fix listing pages empty price problem 
https://andersinno.atlassian.net/browse/SATT-60

### How to test it

- make fresh or make build drush-cr
- rebuild tracking information search api apartment listing https://asuntotuotanto.docker.so/fi/admin/config/search/search-api/index/apartment_listing
- go Haso listing page https://asuntotuotanto.docker.so/fi/asuntohaku/haso
- if you see apartment with empty Asumisoikeusmaksu
  - open a new tab apartment by click tutustu
  - click edit and then click Hintatiedot tab
  - check that Luovutushinta and Alkuperäinen luovutushinta is empty
    - if both values are empty then everything is ok
  - Fill both values and save node (apartment)
- on terminal
  - make shell and then drush cron
- now refresh Haso listing page https://asuntotuotanto.docker.so/fi/admin/config/search/search-api/index/apartment_listing
  - Now listing page should show Luovutushinta value on Asumisoikeusmaksu column
- Find another apartment which shows empty on Asumisoikeusmaksu 
  - Click again Tutustu and edit that apartment node
  - Now fill only Alkuperäinen asumisoikeusmaksu and leave Luovustuhinta field empty
  - Save node
- Now again on terminal make shell and then drush cron
- refresh again haso listing page and now that Alkuperäinen asumisoikeusmaksu value should be on Asumisoikeusmaksu column

In short:
- Haso listing page should show Luovutushinta value on Asumisoikeusmaksu column unless Luovutushinta field is empty so then Alkuperäinen asumisoikeusmaksu will showing on Asumisoikeusmaksu column