### PR TITLE
SATT-66: Revert field_right_of_occupancy_payment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -171,9 +171,9 @@
             "type": "package",
             "package": {
                 "name": "asuntomyynti/react",
-                "version": "1.4.1",
+                "version": "1.4.0",
                 "dist": {
-                    "url": "https://github.com/City-of-Helsinki/asuntomyynti-react/releases/download/v.1.4.1/asuntomyynti-react-1.4.1.zip",
+                    "url": "https://github.com/City-of-Helsinki/asuntomyynti-react/releases/download/v.1.4.0/asuntomyynti-react-1.4.0.zip",
                     "type": "zip"
                 }
             }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d460c3127887bc9eecb7a22c29958a53",
+    "content-hash": "5a4c7d12c808450ac8b1adf9430ddd0e",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -64,10 +64,10 @@
         },
         {
             "name": "asuntomyynti/react",
-            "version": "1.4.1",
+            "version": "1.4.0",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/City-of-Helsinki/asuntomyynti-react/releases/download/v.1.4.1/asuntomyynti-react-1.4.1.zip"
+                "url": "https://github.com/City-of-Helsinki/asuntomyynti-react/releases/download/v.1.4.0/asuntomyynti-react-1.4.0.zip"
             },
             "type": "library"
         },

--- a/conf/cmi/views.view.project_apartments_listing.yml
+++ b/conf/cmi/views.view.project_apartments_listing.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.storage.node.field_living_area
     - field.storage.node.field_ownership_type
     - field.storage.node.field_release_payment
+    - field.storage.node.field_right_of_occupancy_payment
     - node.type.apartment
   module:
     - node
@@ -547,6 +548,72 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        field_right_of_occupancy_payment:
+          id: field_right_of_occupancy_payment
+          table: node__field_right_of_occupancy_payment
+          field: field_right_of_occupancy_payment
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: 'Indeksikorotuksen määrä'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_decimal
+          settings:
+            thousand_separator: ''
+            decimal_separator: .
+            scale: 2
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
       pager:
         type: none
         options:
@@ -923,6 +990,7 @@ display:
         - 'config:field.storage.node.field_living_area'
         - 'config:field.storage.node.field_ownership_type'
         - 'config:field.storage.node.field_release_payment'
+        - 'config:field.storage.node.field_right_of_occupancy_payment'
   project_apartments_listing_block:
     id: project_apartments_listing_block
     display_title: 'Project Apartments Listing'
@@ -951,3 +1019,4 @@ display:
         - 'config:field.storage.node.field_living_area'
         - 'config:field.storage.node.field_ownership_type'
         - 'config:field.storage.node.field_release_payment'
+        - 'config:field.storage.node.field_right_of_occupancy_payment'

--- a/public/themes/custom/asuntotuotanto/templates/views/project/views-view-table--project-apartments-listing.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/views/project/views-view-table--project-apartments-listing.html.twig
@@ -233,6 +233,11 @@
         {% set nid = row.columns.nid.content.0.field_output['#markup']|striptags|trim %}
         {% set price_title = 'Debt-free sales price'|t %}
 
+        {% if debt_free_sales_price == null or debt_free_sales_price == '' or debt_free_sales_price == 0 or debt_free_sales_price == '0,00' %}
+          {% set debt_free_sales_price = row.columns.field_right_of_occupancy_payment.content.0.field_output['#markup']|striptags|trim %}
+          {% set price_title = 'Right of occupancy payment'|t %}
+        {% endif %}
+
         {% if release_payment_price is not empty and release_payment_price > 0 %}
           {% set debt_free_sales_price = release_payment_price %}
         {% endif %}


### PR DESCRIPTION
### Description

Revert previous production deployment HASO-54 related template & react package changes so HITAS and HASO listings are still using field_right_of_occupancy_payment value.