### PR TITLE
ASU-X: SAML authentication mapping configuration page

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -140,6 +140,9 @@
             "drupal/field_group": {
                 "Custom patch to add classes for each horizontal tab": "patches/field_group_horizontal_tabs_classes.patch"
             },
+            "drupal/samlauth": {
+                "https://www.drupal.org/project/samlauth/issues/3424834": "https://git.drupalcode.org/project/samlauth/-/merge_requests/18.patch"
+            },
             "drupal/user_bundle": {
                 "Custom patch prevents install from dying when trying to edit nonexisting admin configuration file.": "./patches/remove_editing_admin_configuration.patch"
             }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d460c3127887bc9eecb7a22c29958a53",
+    "content-hash": "81e5f797fc98413ba6461f573f9584ef",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
### Description

Error encountered when accessing SAML authentication mapping configuration page

When attempting to access admin/config/people/saml/authmap, the following error occurs:
`Symfony\Component\Routing\Exception\InvalidParameterException: Parameter "uid" for route "samlauth.authmap_delete_form" must match "[^/]++" ("" given) to generate a corresponding URL. in Drupal\Core\Routing\UrlGenerator->doGenerate() (line 209 of core/lib/Drupal/Core/Routing/UrlGenerator.php).`

https://www.drupal.org/project/samlauth/issues/3424834