### PR TITLE
eventDispatcher is deprecated

### DIFF
--- a/public/modules/custom/asu_application/src/Form/ApplicationForm.php
+++ b/public/modules/custom/asu_application/src/Form/ApplicationForm.php
@@ -14,6 +14,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerTrait;
 use Drupal\Core\Url;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
@@ -63,6 +64,13 @@ class ApplicationForm extends ContentEntityForm {
    * @var \Drupal\Core\Routing\RouteMatchInterface
    */
   protected $routeMatch;
+
+  /**
+   * The event dispatcher.
+   *
+   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+   */
+  private EventDispatcherInterface $eventDispatcher;
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
### Description

Fixing Sentry message about `$eventDispatcher is deprecated`

`
Deprecated function: Creation of dynamic property Drupal\asu_application\Form\ApplicationForm::$eventDispatcher is deprecated in Drupal\asu_application\Form\ApplicationForm::create() (line 82 of /var/www/html/public/modules/custom/asu_application/src/Form/ApplicationForm.php)
`