### PR TITLE
SATT-54: Twig template changes haso fee

### DIFF
--- a/conf/cmi/core.entity_view_display.node.apartment.default.yml
+++ b/conf/cmi/core.entity_view_display.node.apartment.default.yml
@@ -74,7 +74,7 @@ content:
     type: number_decimal
     label: above
     settings:
-      thousand_separator: ''
+      thousand_separator: ' '
       decimal_separator: .
       scale: 2
       prefix_suffix: true
@@ -231,7 +231,7 @@ content:
     type: number_decimal
     label: above
     settings:
-      thousand_separator: ''
+      thousand_separator: ' '
       decimal_separator: .
       scale: 2
       prefix_suffix: true
@@ -394,7 +394,7 @@ content:
     type: number_decimal
     label: above
     settings:
-      thousand_separator: ''
+      thousand_separator: ' '
       decimal_separator: .
       scale: 2
       prefix_suffix: true

--- a/conf/cmi/views.view.project_apartments_listing.yml
+++ b/conf/cmi/views.view.project_apartments_listing.yml
@@ -342,7 +342,7 @@ display:
             thousand_separator: ' '
             decimal_separator: ','
             scale: 2
-            prefix_suffix: false
+            prefix_suffix: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -405,7 +405,7 @@ display:
           click_sort_column: value
           type: number_decimal
           settings:
-            thousand_separator: ''
+            thousand_separator: ' '
             decimal_separator: .
             scale: 2
             prefix_suffix: true
@@ -600,7 +600,7 @@ display:
           click_sort_column: value
           type: number_decimal
           settings:
-            thousand_separator: ''
+            thousand_separator: ' '
             decimal_separator: .
             scale: 2
             prefix_suffix: true

--- a/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/content/node--apartment--full.html.twig
@@ -90,7 +90,6 @@
 {% set floor = content.field_floor.0 %}
 {% set sales_price = content.field_sales_price.0 %}
 {% set haso_fee = content.field_haso_fee.0 %}
-{% set adjusted_price = content.field_index_adjusted_right_of_oc.0 %}
 {% set alteration_price = content.field_alteration_work.0 %}
 {% set release_payment = content.field_release_payment.0 %}
 {% set loan_share = content.field_loan_share.0 %}
@@ -416,23 +415,15 @@
                     </p>
                   </li>
                 {% endif %}
-                {% if right_of_occupancy_payment|render and right_of_occupancy_payment|render != '0,00€' and right_of_occupancy_payment|render != null %}
+                {% if right_of_occupancy_payment|render and right_of_occupancy_payment|render != '0.00€' and right_of_occupancy_payment|render != null %}
                   <li class="apartment__details-item">
                     <p>
-                      <span>{% trans %}Original right of occupancy payment{% endtrans %}</span>
+                      <span>{% trans %}Index adjustment{% endtrans %}</span>
                       <span>{{ right_of_occupancy_payment }}</span>
                     </p>
                   </li>
                 {% endif %}
-                {% if adjusted_price|render and adjusted_price|render != '0,00€' and adjusted_price|render != null %}
-                  <li class="apartment__details-item">
-                    <p>
-                      <span>{% trans %}Index adjustment{% endtrans %}</span>
-                      <span>{{ adjusted_price }}</span>
-                    </p>
-                  </li>
-                {% endif %}
-                {% if alteration_price|render and alteration_price|render != '0,00€' and alteration_price|render != null %}
+                {% if alteration_price|render and alteration_price|render != '0.00€' and alteration_price|render != null %}
                   <li class="apartment__details-item">
                     <p>
                       <span>{% trans %}Alteration work{% endtrans %}</span>

--- a/public/themes/custom/asuntotuotanto/templates/views/project/views-view-table--project-apartments-listing.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/views/project/views-view-table--project-apartments-listing.html.twig
@@ -261,7 +261,7 @@
             <span>{{ living_area_size }} m<sup>2</sup></span>
           </td>
           <td>
-            <span>{{ debt_free_sales_price }}</span> €
+            <span>{{ debt_free_sales_price }}</span>
           </td>
           <td>
             <span>

--- a/public/themes/custom/asuntotuotanto/templates/views/project/views-view-table--project-apartments-listing.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/views/project/views-view-table--project-apartments-listing.html.twig
@@ -179,6 +179,7 @@
               key is not same as ('field_apartment_structure') and
               key is not same as ('nid') and
               key is not same as ('field_application_url') and
+              key is not same as ('field_haso_fee') and
               key is not same as ('field_right_of_occupancy_payment') %}
                   {% if column.default_classes %}
                     {%
@@ -233,7 +234,6 @@
         {% set living_area_size = row.columns.field_living_area.content.0.field_output['#markup']|striptags|trim %}
         {% set nid = row.columns.nid.content.0.field_output['#markup']|striptags|trim %}
         {% set price_title = 'Debt-free sales price'|t %}
-
         {% if haso_fee is not empty and haso_fee > 0 %}
           {% set debt_free_sales_price = haso_fee %}
         {% endif %}

--- a/public/themes/custom/asuntotuotanto/templates/views/project/views-view-table--project-apartments-listing.html.twig
+++ b/public/themes/custom/asuntotuotanto/templates/views/project/views-view-table--project-apartments-listing.html.twig
@@ -52,9 +52,22 @@
       {% set living_area_size = row.columns.field_living_area.content.0.field_output['#markup']|striptags|trim %}
       {% set nid = row.columns.nid.content.0.field_output['#markup']|striptags|trim %}
       {% set price_title = 'Debt-free sales price'|t %}
+      {% set haso_fee = row.columns.field_haso_fee.content.0.field_output['#markup']|striptags|trim %}
+      {% set release_payment_price = row.columns.field_release_payment.content.0.field_output['#markup']|striptags|trim %}
 
+      {# Go through the different possibilities of the prices that will get shown for mobile. #}
       {% if debt_free_sales_price == null or debt_free_sales_price == '' or debt_free_sales_price == 0 or debt_free_sales_price == '0,00' %}
         {% set debt_free_sales_price = row.columns.field_right_of_occupancy_payment.content.0.field_output['#markup']|striptags|trim %}
+        {% set price_title = 'Right of occupancy payment'|t %}
+      {% endif %}
+
+      {% if haso_fee is not empty and haso_fee > 0 %}
+        {% set debt_free_sales_price = haso_fee %}
+        {% set price_title = 'Right of occupancy payment'|t %}
+      {% endif %}
+
+      {% if release_payment_price is not empty and release_payment_price > 0 %}
+        {% set debt_free_sales_price = release_payment_price %}
         {% set price_title = 'Right of occupancy payment'|t %}
       {% endif %}
 
@@ -108,7 +121,7 @@
                   {{ price_title }}
                 </span>
                 <span>
-                  {{ debt_free_sales_price }} €
+                  {{ debt_free_sales_price }}
                 </span>
               </p>
             </li>
@@ -234,6 +247,8 @@
         {% set living_area_size = row.columns.field_living_area.content.0.field_output['#markup']|striptags|trim %}
         {% set nid = row.columns.nid.content.0.field_output['#markup']|striptags|trim %}
         {% set price_title = 'Debt-free sales price'|t %}
+
+        {# Go through the different possibilities of the prices that will get shown for mobile. #}
         {% if haso_fee is not empty and haso_fee > 0 %}
           {% set debt_free_sales_price = haso_fee %}
         {% endif %}


### PR DESCRIPTION
## Description

Since there is a new field field_haso_fee, there is a need to apply changes to the templates related to it.

- Hiding the table header for haso_fee.
- Changed the separator from , to . in right_of_occupancy_payment and alteration_price.
- Removed the hard coded € sign from desktop and mobile. Configured in view. 
![image](https://github.com/user-attachments/assets/a44a9620-82bf-4877-ae20-252b2fa6eb63)
Image from prod.
- Added thousand separator '  ' so that it is inline with hitas.
- Revised the logic for mobile view for the apartment listing so that it will present the right value according to the values set.