### PR TITLE
SATT-71: Application created by and is admin created

### DIFF
--- a/public/modules/custom/asu_application/asu_application.install
+++ b/public/modules/custom/asu_application/asu_application.install
@@ -119,3 +119,26 @@ function asu_application_grant_permissions() : void {
 
   helfi_platform_config_grant_permissions($permissions);
 }
+
+/**
+ * Add created admin and created by fields to application.
+ */
+function asu_application_update_9007() : void {
+  $fields['created_admin'] = BaseFieldDefinition::create('boolean')
+    ->setLabel(t('Created by admin'))
+    ->setDescription(t('A boolean indicating whether application is created by admin.'))
+    ->setDefaultValue(FALSE);
+
+  $fields['created_by'] = BaseFieldDefinition::create('entity_reference')
+    ->setLabel(t('Created by'))
+    ->setDescription(t('The creator ID of author of the application entity.'))
+    ->setSetting('target_type', 'user')
+    ->setSetting('handler', 'default')
+    ->setRequired(TRUE)
+    ->setReadOnly(TRUE);
+
+  foreach ($fields as $name => $field) {
+    \Drupal::entityDefinitionUpdateManager()
+      ->installFieldStorageDefinition($name, 'asu_application', 'asu_application', $field);
+  }
+}

--- a/public/modules/custom/asu_application/src/Entity/Application.php
+++ b/public/modules/custom/asu_application/src/Entity/Application.php
@@ -288,6 +288,19 @@ class Application extends EditorialContentEntityBase implements ContentEntityInt
         'settings' => [],
       ]);
 
+    $fields['created_admin'] = BaseFieldDefinition::create('boolean')
+      ->setLabel(t('Created by admin'))
+      ->setDescription(t('A boolean indicating whether application is created by admin.'))
+      ->setDefaultValue(FALSE);
+
+    $fields['created_by'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('Created by'))
+      ->setDescription(t('The creator ID of author of the application entity.'))
+      ->setSetting('target_type', 'user')
+      ->setSetting('handler', 'default')
+      ->setRequired(TRUE)
+      ->setReadOnly(TRUE);
+
     $fields['created'] = BaseFieldDefinition::create('created')
       ->setLabel(t('Created'))
       ->setDescription(t('The time that the entity was created.'));
@@ -327,6 +340,8 @@ class Application extends EditorialContentEntityBase implements ContentEntityInt
 
     $user = User::load(\Drupal::currentUser()->id());
     if ($user->bundle() == 'sales') {
+      $created_admin = TRUE;
+
       if (\Drupal::request()->get('user_id')) {
         $user_id = \Drupal::request()->get('user_id');
       }
@@ -336,12 +351,15 @@ class Application extends EditorialContentEntityBase implements ContentEntityInt
     }
     else {
       $user_id = $user->id();
+      $created_admin = FALSE;
     }
 
     $values += [
       'uid' => $user_id,
       'project_id' => $project_id,
       'project' => $project_id,
+      'created_admin' => $created_admin,
+      'created_by' => $user->id(),
     ];
 
   }


### PR DESCRIPTION
### Descrition

Adding created by and is admin created fields to application data so problem solving is easier for future

https://andersinno.atlassian.net/browse/SATT-71

### how to test

use **dev** database and setup saml settings that you can use suomi login

- make fresh
- login as admin
- go re-index both search api indexes https://asuntotuotanto.docker.so/fi/admin/config/search/search-api
- go people listing and get some salesperson user id https://asuntotuotanto.docker.so/fi/admin/people
  - login as salesperson in different browser or incognito mode
- as salesperson go again people listing https://asuntotuotanto.docker.so/fi/admin/people
  - now short by Viimeksi paikalla and add application e.g. Testi Äyrämö or Antero Asiakas on toimenpiteet column 
  - HASO testi 2024 should work
  - when application form is open that is enough you dont need to fill form
- now open database 
  - select asu_application table and filter by id that latest is up
  - check that created_admin is 1 and created by is that salesperson user id which you are logged in
- logout as salesperson
- Now login as suomi ether OP or Aktia
- Go Haso listing page and do application some project
  - just open form is enough so no need to fill it. Just me sure that form is a new and not already exist so you need to apply project where that user is not already apply application
  - so maybe you need to change some dates from some HASO project so you can apply application e.g. HASO testi 2024
- After you have open application form go database again
   - select asu_application table and filter by id that latest is up
   - check that created_admin is 0 and created by is that customer user id which you are logged in