### PR TITLE
SATT-54: Apartment number filter to !=, so that the projects will be …

### DIFF
--- a/conf/cmi/views.view.project_apartments_listing.yml
+++ b/conf/cmi/views.view.project_apartments_listing.yml
@@ -831,7 +831,7 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: string
-          operator: not
+          operator: '!='
           value: A0
           group: 1
           exposed: false


### PR DESCRIPTION
## Description
During the development we noticed an filter issue where apartments were not presented correctly if the apartment number included "A0" without a blank space.

## Fix
Change the view filter configuration to `!=`.

## Testing

- Create apartments with apartment numbers that contain "A01,A02...A09" 
- Previously those were not shown.
- Confirm the apartments show on the apartment listing page.

![image](https://github.com/user-attachments/assets/dd71eccf-3127-4663-aff9-7ce5741e5127)
