### PR TITLE
SATT-68: Samlauth & externalauth module update & custom login module changes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4043,26 +4043,26 @@
         },
         {
             "name": "drupal/externalauth",
-            "version": "2.0.5",
+            "version": "2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/externalauth.git",
-                "reference": "2.0.5"
+                "reference": "2.0.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/externalauth-2.0.5.zip",
-                "reference": "2.0.5",
-                "shasum": "7c262c7ca20d26aae45896daee4249e47b637abc"
+                "url": "https://ftp.drupal.org/files/projects/externalauth-2.0.6.zip",
+                "reference": "2.0.6",
+                "shasum": "0dbc9fbab0901e940d52b239e08f031797f6bd2a"
             },
             "require": {
-                "drupal/core": "^9 || ^10"
+                "drupal/core": "^9.5 || ^10 || ^11"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.5",
-                    "datestamp": "1708329378",
+                    "version": "2.0.6",
+                    "datestamp": "1720689758",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -7540,28 +7540,28 @@
         },
         {
             "name": "drupal/samlauth",
-            "version": "3.9.0",
+            "version": "3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/samlauth.git",
-                "reference": "8.x-3.9"
+                "reference": "8.x-3.10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/samlauth-8.x-3.9.zip",
-                "reference": "8.x-3.9",
-                "shasum": "1af6aec1b9f7f49bd2bc8e023ef53dbbd7329722"
+                "url": "https://ftp.drupal.org/files/projects/samlauth-8.x-3.10.zip",
+                "reference": "8.x-3.10",
+                "shasum": "c7112aa6b765ed9b6879d8d0f39dd9bf5b2c7270"
             },
             "require": {
-                "drupal/core": "^9.2 || ^10",
-                "drupal/externalauth": "^1.3 || ^2",
+                "drupal/core": "^9.5 || ^10 || ^11",
+                "drupal/externalauth": "^1.3 || ^2.0.6",
                 "onelogin/php-saml": "^3.3.1 || ^4"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-3.9",
-                    "datestamp": "1690407017",
+                    "version": "8.x-3.10",
+                    "datestamp": "1723060564",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/public/modules/custom/asu_user/src/AuthService.php
+++ b/public/modules/custom/asu_user/src/AuthService.php
@@ -153,7 +153,7 @@ class AuthService extends SamlService {
 
     $account = $this->externalAuth->load($unique_id, 'samlauth') ?: NULL;
 
-    try{
+    try {
       $this->doLogin($unique_id, $account);
     }
     catch (UserVisibleException $e) {

--- a/public/modules/custom/asu_user/src/Controller/AuthController.php
+++ b/public/modules/custom/asu_user/src/Controller/AuthController.php
@@ -129,20 +129,25 @@ class AuthController extends SamlController {
    * service on the IdP, which should be redirecting back to our ACS endpoint
    * after authenticating the user.
    *
+   * @param bool $force_auth
+   *    (optional) Tell the IdP to force authentication. This should present an
+   *    authentication mechanism to the user even if they are logged in already
+   *    from the IdP's viewpoint. It's up to the IdP to actually implement this.
+   *
    * @return \Drupal\Core\Routing\TrustedRedirectResponse
    *   The HTTP response to send back.
    */
-  public function login() {
-    $function = function () {
+  public function login($force_auth = FALSE) {
+    $function = function () use ($force_auth) {
       global $base_url;
       $config = $this->configFactory->get('samlauth.authentication');
       $return_to = $config->get('login_redirect_url') ?? $base_url . '/user';
 
-      return $this->saml->login($return_to);
+      return $this->saml->login($return_to, [], $force_auth);
     };
     // This response redirects to an external URL in all/common cases. We count
     // on the routing.yml to specify that it's not cacheable.
-    return $this->getShortenedRedirectResponse($function, 'initiating SAML login', '<front>');
+    return $this->getShortenedRedirectResponse($function, $force_auth ? $this->t('initiating SAML login with forced authentication') : $this->t('initiating SAML login'), '<front>');
   }
 
   /**

--- a/public/modules/custom/asu_user/src/Controller/AuthController.php
+++ b/public/modules/custom/asu_user/src/Controller/AuthController.php
@@ -130,9 +130,9 @@ class AuthController extends SamlController {
    * after authenticating the user.
    *
    * @param bool $force_auth
-   *    (optional) Tell the IdP to force authentication. This should present an
-   *    authentication mechanism to the user even if they are logged in already
-   *    from the IdP's viewpoint. It's up to the IdP to actually implement this.
+   *   (optional) Tell the IdP to force authentication. This should present an
+   *   authentication mechanism to the user even if they are logged in already
+   *   from the IdP's viewpoint. It's up to the IdP to actually implement this.
    *
    * @return \Drupal\Core\Routing\TrustedRedirectResponse
    *   The HTTP response to send back.


### PR DESCRIPTION
### Description

Update Samlauth & externalauth contrib modules for latest version. Also update & change asu_user custom module to match Samlauth changes

### How to test

Required on docker-compose:
- ASU_HASH_KEY
- ASU_SAML_CERT
- ASU_SAML_SP
- DRUPAL_AUTH_TOKEN

#### Now testing:
- make fresh
- do not login as admin
- go https://asuntotuotanto.docker.so/
- go login and use suomi fi login
  - you can use what ever option you want but...
  - OP, AKTIA and testitunnistaja are easiest to test (for others you need to Google test accounts, my link to test accounts doesn't work anymore...)
    - on testitunnistaja: you can check more test accounts on "Löydät lisätietoja käytettävissä olevista testitunnisteista [Palveluhallinnasta](https://palveluhallinta.suomi.fi/fi/tuki/artikkelit/5a82ef7ab03cdc41de664a2b)."
- Check that suomi fi login is working as normal
- logout
- now you can login as admin if you want to checked things
- you can check things like:
  - you can check login history https://asuntotuotanto.docker.so/fi/admin/reports/login-history
  - you can check that authmap listing is working https://asuntotuotanto.docker.so/fi/admin/config/people/saml/authmap 