### PR TITLE
SATT-69: remove asu_application_grant_permissions hooks

### DIFF
--- a/public/modules/custom/asu_application/asu_application.install
+++ b/public/modules/custom/asu_application/asu_application.install
@@ -14,9 +14,9 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 /**
  * Implements hook_install().
  */
-function asu_application_install() : void {
-  asu_application_grant_permissions();
-}
+//function asu_application_install() : void {
+//  asu_application_grant_permissions();
+//}
 
 /**
  * Installs error field to application.
@@ -103,19 +103,19 @@ function asu_application_update_9006() {
 /**
  * Grants required permissions.
  */
-function asu_application_grant_permissions() : void {
-  $permissions = [
-    'admin' => [
-      'administer applications',
-    ],
-    'anonymous' => [
-      'create application',
-    ],
-    'authenticated' => [
-      'create application',
-      'view application',
-    ],
-  ];
-
-  helfi_platform_config_grant_permissions($permissions);
-}
+//function asu_application_grant_permissions() : void {
+//  $permissions = [
+//    'admin' => [
+//      'administer applications',
+//    ],
+//    'anonymous' => [
+//      'create application',
+//    ],
+//    'authenticated' => [
+//      'create application',
+//      'view application',
+//    ],
+//  ];
+//
+//  helfi_platform_config_grant_permissions($permissions);
+//}


### PR DESCRIPTION
### Description

Remove asu_application_grant_permissions hooks

```
In helfi_platform_config.module line 315:
                           
  Role (admin) not found.
```