### PR TITLE
SATT-68: Added cron-entrypoint.sh file

### DIFF
--- a/docker/openshift/cron-entrypoint.sh
+++ b/docker/openshift/cron-entrypoint.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+source /init.sh
+
+echo "Starting cron: $(date)"
+
+# You can add any additional cron "daemons" to docker/openshift/crons/ folder.
+#
+# Example:
+# @code
+# #!/bin/bash
+# while true
+# do
+#   drush some-command
+#   sleep 600
+# done
+# @endcode
+
+for cron in /crons/*.sh; do
+  # Skip legacy base.sh script if it exists.
+  # Skip Kubernetes hooks that are stored in crons directory.
+  if [[ "${cron##*/}" == "base.sh" ]] || [[ "${cron##*/}" == *-hook.sh ]]; then
+    continue
+  elif [[ -r "$cron" ]]; then
+    echo "Starting $cron"
+    exec "$cron" &
+  fi
+done
+
+while true
+do
+  # Rudimentary process supervisor:
+  # Waits for the next process to terminate. The parent
+  # process is killed if any subprocess exists with failure.
+  # OpenShift should then restart the cron pod.
+  wait -n
+  exit_code=$?
+  if [[ "$exit_code" -ne 0 ]]; then
+    output_error_message "Cron subprocess failed with exit code $exit_code"
+    exit 1
+  fi
+done


### PR DESCRIPTION
### Description

Added cron-entrypoint.sh file to fix 

```
STEP 10/14: COPY docker/openshift/cron-entrypoint.sh /usr/local/bin/cron-entrypoint
error: build error: building at STEP "COPY docker/openshift/cron-entrypoint.sh /usr/local/bin/cron-entrypoint": checking on sources under "/tmp/build/inputs": copier: stat: "/docker/openshift/cron-entrypoint.sh": no such file or directory
error: the build hki-kanslia-aok-asuntotuotanto-dev/asuntotuotanto-566 status is "Failed"
```