### PR TITLE
SATT-86: Add field to show when application was sent to Django

### DIFF
--- a/public/modules/custom/asu_application/asu_application.install
+++ b/public/modules/custom/asu_application/asu_application.install
@@ -147,3 +147,18 @@ function asu_application_update_9007() : void {
       ->installFieldStorageDefinition($name, 'asu_application', 'asu_application', $field);
   }
 }
+
+/**
+ * Add created to Django field to application.
+ */
+function asu_application_update_9008() : void {
+  $fields['create_to_django'] = BaseFieldDefinition::create('datetime')
+    ->setLabel(t('Created to Django'))
+    ->setDescription(t('A datetime value when application is sent to Django.'))
+    ->setDefaultValue(FALSE);
+
+  foreach ($fields as $name => $field) {
+    \Drupal::entityDefinitionUpdateManager()
+      ->installFieldStorageDefinition($name, 'asu_application', 'asu_application', $field);
+  }
+}

--- a/public/modules/custom/asu_application/src/Entity/Application.php
+++ b/public/modules/custom/asu_application/src/Entity/Application.php
@@ -301,6 +301,11 @@ class Application extends EditorialContentEntityBase implements ContentEntityInt
       ->setRequired(TRUE)
       ->setReadOnly(TRUE);
 
+    $fields['create_to_django'] = BaseFieldDefinition::create('datetime')
+      ->setLabel(t('Created to Django'))
+      ->setDescription(t('A datetime value when application is sent to Django.'))
+      ->setReadOnly(TRUE);
+
     $fields['created'] = BaseFieldDefinition::create('created')
       ->setLabel(t('Created'))
       ->setDescription(t('The time that the entity was created.'));
@@ -360,6 +365,7 @@ class Application extends EditorialContentEntityBase implements ContentEntityInt
       'project' => $project_id,
       'created_admin' => $created_admin,
       'created_by' => $user->id(),
+      'create_to_django' => NULL,
     ];
 
   }

--- a/public/modules/custom/asu_application/src/EventSubscriber/ApplicationSubscriber.php
+++ b/public/modules/custom/asu_application/src/EventSubscriber/ApplicationSubscriber.php
@@ -145,6 +145,7 @@ class ApplicationSubscriber implements EventSubscriberInterface {
 
       $application->set('field_locked', 1);
       $application->set('error', NULL);
+      $application->set('create_to_django', \Drupal::time()->getCurrentTime());
       $application->save();
 
       $this->logger->notice(
@@ -251,6 +252,7 @@ class ApplicationSubscriber implements EventSubscriberInterface {
 
       $application->set('field_locked', 1);
       $application->set('error', NULL);
+      $application->set('create_to_django', \Drupal::time()->getCurrentTime());
       $application->save();
 
       $this->messenger()->addStatus($this->t('The application has been submitted successfully.


### PR DESCRIPTION
### Description

Add a new field to save date time when application is sent to Django

### How to test it

- make sure that you have ASU_DJANGO_BACKEND_URL and DRUPAL_AUTH_TOKEN setup on compose.yaml
- make fresh
- make shell
- `drush uli --uid=100` or `drush uli --uid=100`
- go applications page (hakemukset)
- there should be Application drafts if not then try another user
- edit draft application
- check that everything is ok and special be sure that personal id is correct. if you dont have suomi fi account information ask for @tvalimaa 
- sent application without errors (do not close that page)
- now open sql on sequel or make shell & drush sql-cli
- get application id from application which you edited on url 
- check that create_to_django have timestamp value on sql `select create_to_django from asu_application where id = <id from url>;`