### PR TITLE
SATT-83: residence number max value check

### DIFF
--- a/public/modules/custom/asu_application/src/Form/ApplicationForm.php
+++ b/public/modules/custom/asu_application/src/Form/ApplicationForm.php
@@ -308,7 +308,9 @@ class ApplicationForm extends ContentEntityForm {
     }
 
     // Residence number check.
-    if (isset($formValues['field_right_of_residence_number'][0]) && !is_numeric($formValues['field_right_of_residence_number'][0]['value'])) {
+    if (isset($formValues['field_right_of_residence_number'][0]) &&
+      !is_numeric($formValues['field_right_of_residence_number'][0]['value']) ||
+      (int) $formValues['field_right_of_residence_number'][0]['value'] > 2147483647) {
       $fieldTitle = (string) $form["field_right_of_residence_number"]['widget'][0]['#title'];
       $form_state->setErrorByName($applicant_field, $this->t('Check @field', ['@field' => $fieldTitle]));
     }


### PR DESCRIPTION
### Description

Fixing right_of_residence max value validation check

resulted in a `400 Bad Request` response:\n{\"right_of_residence\":[{\"message\":\"Tämän arvon on oltava pienempi tai yhtä suuri kuin 2147483647.\",\"code\":\"max_value\" 


### how to test

- use dev database
- make fresh or make drush-cr
- rebuild and re-index apartment listing search api if you havent project already running
- logout as admin
- make shell
- drush uli --uid=104
- create application https://asuntotuotanto.docker.so/fi/asuntohaku/haso/haso-2024-toukokuu-testi-hasokatu-89
- check that Asumisoikeusnumero can max 2147483647 so if you trying to add higher number you should give error message
- try first higher number than 2147483647 and then lower or equal to 2147483647