### PR TITLE
SATT-96: Disable active user email send

### DIFF
--- a/conf/cmi/user.settings.yml
+++ b/conf/cmi/user.settings.yml
@@ -6,7 +6,7 @@ verify_mail: false
 notify:
   cancel_confirm: true
   password_reset: true
-  status_activated: true
+  status_activated: false
   status_blocked: false
   status_canceled: false
   register_admin_created: true


### PR DESCRIPTION
### Description

Disable active user account email sending

### How to test

- make fresh or make drush-cim
- login as admin
- go check that Ilmoita käyttäjälle kun tili on aktivoitu (Tilin aktivointi) setting is off https://asuntotuotanto.docker.so/fi/admin/config/people/accounts