### PR TITLE
SATT-89: Show latest update timestamp

### DIFF
--- a/public/modules/custom/asu_application/src/Entity/Application.php
+++ b/public/modules/custom/asu_application/src/Entity/Application.php
@@ -169,6 +169,20 @@ class Application extends EditorialContentEntityBase implements ContentEntityInt
   }
 
   /**
+   * Application last timestamp.
+   *
+   * @return int
+   *   Application updated or sent timestamp.
+   */
+  public function getLatestTimestamp(): int {
+    if (!reset($this->values["create_to_django"])) {
+      return reset($this->values["changed"]);
+    }
+
+    return reset($this->values["create_to_django"]);
+  }
+
+  /**
    * Has there been an error while sending api request to backend.
    *
    * @return bool

--- a/public/modules/custom/asu_application/src/Form/SalespersonApplicationForm.php
+++ b/public/modules/custom/asu_application/src/Form/SalespersonApplicationForm.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\asu_application\Form;
 
+use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -30,13 +31,17 @@ class SalespersonApplicationForm extends FormBase {
    *   The entity type manager service.
    * @param \Drupal\search_api\ParseMode\ParseModePluginManager $parseModeManager
    *   The parse mode manager.
+   * @param \Drupal\Core\Datetime\DateFormatterInterface $date
+   *   The date service.
    */
   public function __construct(
     EntityTypeManagerInterface $entityTypeManager,
     ParseModePluginManager $parseModeManager,
+    DateFormatterInterface $date,
   ) {
     $this->entityTypeManager = $entityTypeManager;
     $this->parseModeManager = $parseModeManager;
+    $this->date = $date;
   }
 
   /**
@@ -46,6 +51,7 @@ class SalespersonApplicationForm extends FormBase {
     return new static(
       $container->get('entity_type.manager'),
       $container->get('plugin.manager.search_api.parse_mode'),
+      $container->get('date.formatter'),
     );
   }
 
@@ -90,9 +96,10 @@ class SalespersonApplicationForm extends FormBase {
 
       if (!empty($userApplications)) {
         foreach ($userApplications as $key => $application) {
-          $status = $application->isLocked() ? $this->t('Already sent:') : $this->t('Draft:');
+          $status = $application->isLocked() ? $this->t('Already sent') : $this->t('Draft');
+          $latest_change = $this->date->format($application->getLatestTimestamp(), 'long');
           $form['user_applications_' . $key] = [
-            '#markup' => $status . ' ' . $projects[$application->getProjectId()]['title'] . '<br>',
+            '#markup' => $status . ' ( ' . $latest_change . ' ): ' . $projects[$application->getProjectId()]['title'] . '<br>',
           ];
         }
       }


### PR DESCRIPTION
### Description

Showing draft or sent to django timestamp to salesperson when adding application behalf on customer


### how to test

- make fresh
- login as admin
- rebuild track information and re-index search apartment 
- logout
- login as salesperson like uid 85
- login as salesperson
- go user listing page
- filter users by last logged in value
- select tero Äyrämö and click Tee hakemus uudelle käyttäjälle
- now you should see timestamps on application list
- login as tero uid 104 on other browser
- go edit some draft and kept that in draft
- now on salesperson browser refresh and check that timestamp is change and correct
- you can also try sent application and be sure that sent to django time is correct