### PR TITLE
SATT-105: Undefined array key application_status

### DIFF
--- a/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
+++ b/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
@@ -913,15 +913,15 @@ function format_date_to_unix_timestamp($string) {
  */
 function get_apartment_application_status($application_status) {
   $application_status_mapping = [
-    "NONE" => t('Few applicants'),
-    "LOW" => t('Few applicants'),
-    "MEDIUM" => t('A little applicants'),
-    "HIGH" => t('A lot of applicants'),
+    "none" => t('Few applicants'),
+    "low" => t('Few applicants'),
+    "medium" => t('A little applicants'),
+    "high" => t('A lot of applicants'),
   ];
 
   return [
     "status" => strtolower($application_status),
-    "label" => $application_status_mapping[$application_status],
+    "label" => $application_status_mapping[strtolower($application_status)],
   ];
 }
 


### PR DESCRIPTION
### Description

Fix project apartment listing page application status undefined array key warning


### How to test

- make fresh
- login as admin
- rebuild tracking information and re-index apartment listing page
- logout
- go haso or hitas listing page
- open some project which has multiple apartments
- check on project page that apartment listing is showing status and color on apartment status
- you can also check on docker logs that you dont see `Undefined array key \"low\" in get_apartment_application_status()` on logs