### PR TITLE
SATT-101: eventDispatcher and personal_id php errors and warnings

### DIFF
--- a/public/modules/custom/asu_application/src/Form/ApplicationForm.php
+++ b/public/modules/custom/asu_application/src/Form/ApplicationForm.php
@@ -71,7 +71,7 @@ class ApplicationForm extends ContentEntityForm {
    *
    * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
    */
-  private EventDispatcherInterface $eventDispatcher;
+  private ?EventDispatcherInterface $eventDispatcher = NULL;
 
   /**
    * {@inheritdoc}
@@ -353,37 +353,10 @@ class ApplicationForm extends ContentEntityForm {
     $control_character = substr($personalId, -1);
     $divider = $this->getPersonalIdDivider($birthDate);
     $alphabet = [
-      '0',
-      '1',
-      '2',
-      '3',
-      '4',
-      '5',
-      '6',
-      '7',
-      '8',
-      '9',
-      'A',
-      'B',
-      'C',
-      'D',
-      'E',
-      'F',
-      'H',
-      'J',
-      'K',
-      'L',
-      'M',
-      'N',
-      'P',
-      'R',
-      'S',
-      'T',
-      'U',
-      'V',
-      'W',
-      'X',
-      'Y',
+      '0', '1', '2', '3', '4', '5', '6', '7',
+      '8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
+      'H', 'J', 'K', 'L', 'M', 'N', 'P', 'R',
+      'S', 'T', 'U', 'V', 'W', 'X', 'Y',
     ];
 
     // Check that perosnal id has value and divider is not null.

--- a/public/modules/custom/asu_application/src/Plugin/Field/FieldWidget/MainApplicantWidget.php
+++ b/public/modules/custom/asu_application/src/Plugin/Field/FieldWidget/MainApplicantWidget.php
@@ -117,13 +117,15 @@ class MainApplicantWidget extends WidgetBase {
       '#required' => TRUE,
     ];
 
+    $personal_id_default = (!empty($items->getValue()[$delta]['personal_id'])) ? substr($items->getValue()[$delta]['personal_id'], -4) : NULL;
+
     $element['personal_id'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Personal id'),
       '#description' => $this->t('last 4 characters'),
       '#minlength' => 5,
       '#maxlength' => 5,
-      '#default_value' => substr($items->getValue()[$delta]['personal_id'], -4) ?? '',
+      '#default_value' => $personal_id_default ?? '',
       '#required' => TRUE,
     ];
 


### PR DESCRIPTION
### Description

Fixing: 

`PHP message: Uncaught PHP Exception Error: "Typed property Drupal\asu_application\Form\ApplicationForm::$eventDispatcher must not be accessed before initialization" at /var/www/html/public/modules/custom/asu_application/src/Form/ApplicationForm.php line 417`

and

`{"message":"Deprecated function: substr(): Passing null to parameter #1 ($string) of type string is deprecated in Drupal\\asu_application\\Plugin\\Field\\FieldWidget\\MainApplicantWidget->formElement() (line 126 of /app/public/modules/custom/asu_application/src/Plugin/Field/FieldWidget/MainApplicantWidget.php)`


### How to test it

- make fresh
- login as admin
- go check some application id on database which is sent to django
- open docker logs
- open application /application/x/edit
- check logs that you dont see any of those two errors