### PR TITLE
SATT-81: Apartment select ajax broke application form

### DIFF
--- a/public/modules/custom/asu_application/src/Form/ApplicationForm.php
+++ b/public/modules/custom/asu_application/src/Form/ApplicationForm.php
@@ -320,11 +320,11 @@ class ApplicationForm extends ContentEntityForm {
     }
 
     // Residence number check.
-    if (isset($formValues['field_right_of_residence_number'][0]) &&
+    if (isset($formValues['field_right_of_residence_number'][0]['value']) &&
       !is_numeric($formValues['field_right_of_residence_number'][0]['value']) ||
       (int) $formValues['field_right_of_residence_number'][0]['value'] > 2147483647) {
       $fieldTitle = (string) $form["field_right_of_residence_number"]['widget'][0]['#title'];
-      $form_state->setErrorByName($applicant_field, $this->t('Check @field', ['@field' => $fieldTitle]));
+      $form_state->setErrorByName($fieldTitle, $this->t('Check @field', ['@field' => $fieldTitle]));
     }
 
     $triggerName = $form_state->getTriggeringElement()['#name'];
@@ -406,7 +406,7 @@ class ApplicationForm extends ContentEntityForm {
     }
 
     // Individual number cannot be 000 or 001.
-    if ($individual_number == '000' || $individual_number == '001') {
+    if ($individual_number == '000' || $individual_number == '001' || !is_numeric($individual_number)) {
       return FALSE;
     }
 

--- a/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
+++ b/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
@@ -47,7 +47,12 @@ function asuntotuotanto_preprocess(&$variables) {
  */
 function asuntotuotanto_theme_suggestions_alter(array &$suggestions, array $variables, $hook) {
   if ($hook == 'form' & !empty($variables['element']['#id'])) {
+    $white_list = ['asu_application_haso_form', 'asu_application_hitas_form'];
     $suggestions[] = 'form__' . str_replace('-', '_', $variables['element']['#id']);
+
+    if(in_array($variables['element']['#form_id'], $white_list)) {
+      $suggestions[] = 'form__' . str_replace('-', '_', $variables['element']['#form_id']);
+    }
   }
 }
 

--- a/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
+++ b/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
@@ -50,7 +50,7 @@ function asuntotuotanto_theme_suggestions_alter(array &$suggestions, array $vari
     $white_list = ['asu_application_haso_form', 'asu_application_hitas_form'];
     $suggestions[] = 'form__' . str_replace('-', '_', $variables['element']['#id']);
 
-    if(in_array($variables['element']['#form_id'], $white_list)) {
+    if (in_array($variables['element']['#form_id'], $white_list)) {
       $suggestions[] = 'form__' . str_replace('-', '_', $variables['element']['#form_id']);
     }
   }


### PR DESCRIPTION
### Description

Related adding personal id check to application form it broke form after validation. Problem was apartment selection ajax which changed form id and theme hook didnt load correct template


### How to test

- make fresh
- login as admin
- search api: rebuild trackinformation and re-index both indexes
- logout
- login as salesperson via uli
- go person listing page and "Luo hakemus uudelle käyttäjälle"
- add at least 2 apartments and leave some errors on the form 
- try to sent form with errors and check that form is looking ok after it shows errors