### PR TITLE
SATT-X: Remove audit ignore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,9 +89,6 @@
             "zaporylie/composer-drupal-optimizations": true,
             "php-http/discovery": true,
             "phpstan/extension-installer": true
-        },
-        "audit": {
-            "ignore": ["GHSA-mg8j-w93w-xjgc"]
         }
     },
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -22292,7 +22292,7 @@
             "version": "2.3.0",
             "source": {
                 "type": "git",
-                "url": "https://git.drupalcode.org/project/dtt/",
+                "url": "https://git.drupalcode.org/project/dtt.git",
                 "reference": "9385da6be0db48ecdb27e6646ae2bb0864c1dcee"
             },
             "require": {
@@ -22349,7 +22349,7 @@
     },
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
After the deployment of 10.3.6 we can remove the audit ignore from composer.json