### PR TITLE
SATT-117: Error: Call to a member function save() on null in Apartmen…

### DIFF
--- a/public/modules/custom/asu_content/src/Plugin/QueueWorker/ApartmentUpdateWorker.php
+++ b/public/modules/custom/asu_content/src/Plugin/QueueWorker/ApartmentUpdateWorker.php
@@ -58,8 +58,9 @@ class ApartmentUpdateWorker extends QueueWorkerBase implements ContainerFactoryP
    * {@inheritdoc}
    */
   public function processItem($data) {
-    $entity = $this->entityTypeManager->getStorage('node')->load($data->nid);
-    $entity->save();
+    if ($entity = $this->entityTypeManager->getStorage('node')->load($data->nid)) {
+      $entity->save();
+    }
   }
 
 }


### PR DESCRIPTION
### Description

drush queue:run asu_content_queue_worker gives:

[error]  Error: Call to a member function save() on null in Drupal\asu_content\Plugin\QueueWorker\ApartmentUpdateWorker->processItem() (line 62 of 