### PR TITLE
ASU-1713: Add construction_year and completion_date to Apartment index on Elasticsearch

### DIFF
--- a/conf/cmi/search_api.index.apartment.yml
+++ b/conf/cmi/search_api.index.apartment.yml
@@ -622,6 +622,16 @@ field_settings:
     datasource_id: 'entity:node'
     property_path: 'search_api_reverse_entity_references_node__field_apartments:field_estimated_completion_date'
     type: asu_date_time
+  project_completion_date:
+    label: 'Completion date'
+    datasource_id: 'entity:node'
+    property_path: 'search_api_reverse_entity_references_node__field_apartments:field_completion_date'
+    type: asu_date_time
+  project_construction_year:
+    label: 'Completion date'
+    datasource_id: 'entity:node'
+    property_path: 'search_api_reverse_entity_references_node__field_apartments:field_construction_year'
+    type: integer
   project_has_elevator:
     label: Elevator
     datasource_id: 'entity:node'


### PR DESCRIPTION
Need to run `drush cim` to update the ELS configuration and then reindex.