### PR TITLE
ASU-1739: Add necessary fields to Drupal and ElasticSearch for new contract template

### DIFF
--- a/conf/cmi/core.entity_form_display.node.project.default.yml
+++ b/conf/cmi/core.entity_form_display.node.project.default.yml
@@ -104,6 +104,7 @@ dependencies:
     - field.field.node.project.field_transfer_restriction
     - field.field.node.project.field_upcoming_description
     - field.field.node.project.field_usage_fees
+    - field.field.node.project.field_use_complete_contract
     - field.field.node.project.field_virtual_presentation_url
     - field.field.node.project.field_warranty_deposit_releas
     - field.field.node.project.field_zoning_info
@@ -1138,6 +1139,13 @@ content:
     settings:
       rows: 5
       placeholder: ''
+    third_party_settings: {  }
+  field_use_complete_contract:
+    type: boolean_checkbox
+    weight: 121
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   field_virtual_presentation_url:
     type: link_default

--- a/conf/cmi/core.entity_form_display.node.project.default.yml
+++ b/conf/cmi/core.entity_form_display.node.project.default.yml
@@ -354,6 +354,7 @@ third_party_settings:
         - field_documents_delivered
         - field_other_terms
         - field_transfer_of_shares_date
+        - field_use_complete_contract
       label: 'Kauppakirjan tiedot'
       region: content
       parent_name: group_project_tabs
@@ -1151,7 +1152,7 @@ content:
     third_party_settings: {  }
   field_use_complete_contract:
     type: boolean_checkbox
-    weight: 121
+    weight: 115
     region: content
     settings:
       display_label: true

--- a/conf/cmi/core.entity_form_display.node.project.default.yml
+++ b/conf/cmi/core.entity_form_display.node.project.default.yml
@@ -101,6 +101,7 @@ dependencies:
     - field.field.node.project.field_state_of_sale
     - field.field.node.project.field_street_address
     - field.field.node.project.field_tasks
+    - field.field.node.project.field_transfer_of_shares_date
     - field.field.node.project.field_transfer_restriction
     - field.field.node.project.field_upcoming_description
     - field.field.node.project.field_usage_fees
@@ -352,6 +353,7 @@ third_party_settings:
         - field_construction_permit_claim
         - field_documents_delivered
         - field_other_terms
+        - field_transfer_of_shares_date
       label: 'Kauppakirjan tiedot'
       region: content
       parent_name: group_project_tabs
@@ -460,6 +462,7 @@ content:
       collapsible: false
       collapsed: false
       revision: false
+      removed_reference: optional
     third_party_settings: {  }
   field_application_end_time:
     type: datetime_default
@@ -1114,6 +1117,12 @@ content:
   field_tasks:
     type: tasklist_widget
     weight: 47
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_transfer_of_shares_date:
+    type: datetime_default
+    weight: 114
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/cmi/core.entity_view_display.node.project.default.yml
+++ b/conf/cmi/core.entity_view_display.node.project.default.yml
@@ -101,6 +101,7 @@ dependencies:
     - field.field.node.project.field_state_of_sale
     - field.field.node.project.field_street_address
     - field.field.node.project.field_tasks
+    - field.field.node.project.field_transfer_of_shares_date
     - field.field.node.project.field_transfer_restriction
     - field.field.node.project.field_upcoming_description
     - field.field.node.project.field_usage_fees
@@ -862,6 +863,15 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 33
+    region: content
+  field_transfer_of_shares_date:
+    type: datetime_default
+    label: above
+    settings:
+      timezone_override: ''
+      format_type: medium
+    third_party_settings: {  }
+    weight: 89
     region: content
   field_transfer_restriction:
     type: boolean

--- a/conf/cmi/core.entity_view_display.node.project.default.yml
+++ b/conf/cmi/core.entity_view_display.node.project.default.yml
@@ -104,6 +104,7 @@ dependencies:
     - field.field.node.project.field_transfer_restriction
     - field.field.node.project.field_upcoming_description
     - field.field.node.project.field_usage_fees
+    - field.field.node.project.field_use_complete_contract
     - field.field.node.project.field_virtual_presentation_url
     - field.field.node.project.field_warranty_deposit_releas
     - field.field.node.project.field_zoning_info
@@ -885,6 +886,16 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 48
+    region: content
+  field_use_complete_contract:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 88
     region: content
   field_warranty_deposit_releas:
     type: datetime_default

--- a/conf/cmi/core.entity_view_display.node.project.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.project.teaser.yml
@@ -105,6 +105,7 @@ dependencies:
     - field.field.node.project.field_transfer_restriction
     - field.field.node.project.field_upcoming_description
     - field.field.node.project.field_usage_fees
+    - field.field.node.project.field_use_complete_contract
     - field.field.node.project.field_virtual_presentation_url
     - field.field.node.project.field_warranty_deposit_releas
     - field.field.node.project.field_zoning_info
@@ -224,6 +225,7 @@ hidden:
   field_transfer_restriction: true
   field_upcoming_description: true
   field_usage_fees: true
+  field_use_complete_contract: true
   field_virtual_presentation_url: true
   field_warranty_deposit_releas: true
   field_zoning_info: true

--- a/conf/cmi/core.entity_view_display.node.project.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.project.teaser.yml
@@ -102,6 +102,7 @@ dependencies:
     - field.field.node.project.field_state_of_sale
     - field.field.node.project.field_street_address
     - field.field.node.project.field_tasks
+    - field.field.node.project.field_transfer_of_shares_date
     - field.field.node.project.field_transfer_restriction
     - field.field.node.project.field_upcoming_description
     - field.field.node.project.field_usage_fees
@@ -222,6 +223,7 @@ hidden:
   field_state_of_sale: true
   field_street_address: true
   field_tasks: true
+  field_transfer_of_shares_date: true
   field_transfer_restriction: true
   field_upcoming_description: true
   field_usage_fees: true

--- a/conf/cmi/core.entity_view_display.node.project.teaser_admin.yml
+++ b/conf/cmi/core.entity_view_display.node.project.teaser_admin.yml
@@ -102,6 +102,7 @@ dependencies:
     - field.field.node.project.field_state_of_sale
     - field.field.node.project.field_street_address
     - field.field.node.project.field_tasks
+    - field.field.node.project.field_transfer_of_shares_date
     - field.field.node.project.field_transfer_restriction
     - field.field.node.project.field_upcoming_description
     - field.field.node.project.field_usage_fees
@@ -258,6 +259,7 @@ hidden:
   field_site_renter: true
   field_state_of_sale: true
   field_tasks: true
+  field_transfer_of_shares_date: true
   field_transfer_restriction: true
   field_upcoming_description: true
   field_usage_fees: true

--- a/conf/cmi/core.entity_view_display.node.project.teaser_admin.yml
+++ b/conf/cmi/core.entity_view_display.node.project.teaser_admin.yml
@@ -105,6 +105,7 @@ dependencies:
     - field.field.node.project.field_transfer_restriction
     - field.field.node.project.field_upcoming_description
     - field.field.node.project.field_usage_fees
+    - field.field.node.project.field_use_complete_contract
     - field.field.node.project.field_virtual_presentation_url
     - field.field.node.project.field_warranty_deposit_releas
     - field.field.node.project.field_zoning_info
@@ -260,6 +261,7 @@ hidden:
   field_transfer_restriction: true
   field_upcoming_description: true
   field_usage_fees: true
+  field_use_complete_contract: true
   field_virtual_presentation_url: true
   field_warranty_deposit_releas: true
   field_zoning_info: true

--- a/conf/cmi/core.entity_view_display.node.project.teaser_media_bank.yml
+++ b/conf/cmi/core.entity_view_display.node.project.teaser_media_bank.yml
@@ -105,6 +105,7 @@ dependencies:
     - field.field.node.project.field_transfer_restriction
     - field.field.node.project.field_upcoming_description
     - field.field.node.project.field_usage_fees
+    - field.field.node.project.field_use_complete_contract
     - field.field.node.project.field_virtual_presentation_url
     - field.field.node.project.field_warranty_deposit_releas
     - field.field.node.project.field_zoning_info
@@ -301,6 +302,7 @@ hidden:
   field_transfer_restriction: true
   field_upcoming_description: true
   field_usage_fees: true
+  field_use_complete_contract: true
   field_virtual_presentation_url: true
   field_warranty_deposit_releas: true
   field_zoning_info: true

--- a/conf/cmi/core.entity_view_display.node.project.teaser_media_bank.yml
+++ b/conf/cmi/core.entity_view_display.node.project.teaser_media_bank.yml
@@ -102,6 +102,7 @@ dependencies:
     - field.field.node.project.field_state_of_sale
     - field.field.node.project.field_street_address
     - field.field.node.project.field_tasks
+    - field.field.node.project.field_transfer_of_shares_date
     - field.field.node.project.field_transfer_restriction
     - field.field.node.project.field_upcoming_description
     - field.field.node.project.field_usage_fees
@@ -299,6 +300,7 @@ hidden:
   field_site_renter: true
   field_state_of_sale: true
   field_tasks: true
+  field_transfer_of_shares_date: true
   field_transfer_restriction: true
   field_upcoming_description: true
   field_usage_fees: true

--- a/conf/cmi/field.field.node.project.field_transfer_of_shares_date.yml
+++ b/conf/cmi/field.field.node.project.field_transfer_of_shares_date.yml
@@ -1,0 +1,21 @@
+uuid: 3ca94999-0162-4973-8f52-d7192abe9b88
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_transfer_of_shares_date
+    - node.type.project
+  module:
+    - datetime
+id: node.project.field_transfer_of_shares_date
+field_name: field_transfer_of_shares_date
+entity_type: node
+bundle: project
+label: 'Osakekirjan luovutuspäivämäärä'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/conf/cmi/field.field.node.project.field_use_complete_contract.yml
+++ b/conf/cmi/field.field.node.project.field_use_complete_contract.yml
@@ -1,0 +1,23 @@
+uuid: f4e2a3aa-e97a-465a-8f12-52995cbc1023
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_use_complete_contract
+    - node.type.project
+id: node.project.field_use_complete_contract
+field_name: field_use_complete_contract
+entity_type: node
+bundle: project
+label: 'Käytä valmiin asunnon kauppakirjaa'
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: Kyllä
+  off_label: Ei
+field_type: boolean

--- a/conf/cmi/field.field.node.project.field_use_complete_contract.yml
+++ b/conf/cmi/field.field.node.project.field_use_complete_contract.yml
@@ -11,7 +11,7 @@ entity_type: node
 bundle: project
 label: 'Käytä valmiin asunnon kauppakirjaa'
 description: ''
-required: true
+required: false
 translatable: false
 default_value:
   -

--- a/conf/cmi/field.storage.node.field_transfer_of_shares_date.yml
+++ b/conf/cmi/field.storage.node.field_transfer_of_shares_date.yml
@@ -1,0 +1,20 @@
+uuid: 48ef6545-c988-426d-a179-def7ad5bd885
+langcode: fi
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_transfer_of_shares_date
+field_name: field_transfer_of_shares_date
+entity_type: node
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_use_complete_contract.yml
+++ b/conf/cmi/field.storage.node.field_use_complete_contract.yml
@@ -1,0 +1,18 @@
+uuid: 6ac97abd-8615-471f-8edb-2c2fe1fd02a7
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_use_complete_contract
+field_name: field_use_complete_contract
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/search_api.index.apartment.yml
+++ b/conf/cmi/search_api.index.apartment.yml
@@ -833,6 +833,11 @@ field_settings:
     datasource_id: 'entity:node'
     property_path: 'search_api_reverse_entity_references_node__field_apartments:field_zoning_status'
     type: string
+  project_transfer_of_shares_date:
+    label: 'Transfer of shares date'
+    datasource_id: 'entity:node'
+    property_path: 'search_api_reverse_entity_references_node__field_apartments:field_transfer_of_shares_date'
+    type: date
   publish_on_etuovi:
     label: 'Publish on etuovi'
     datasource_id: 'entity:node'

--- a/conf/cmi/search_api.index.apartment.yml
+++ b/conf/cmi/search_api.index.apartment.yml
@@ -372,11 +372,21 @@ field_settings:
     datasource_id: 'entity:node'
     property_path: 'search_api_reverse_entity_references_node__field_apartments:field_city'
     type: string
+  project_completion_date:
+    label: 'Completion date'
+    datasource_id: 'entity:node'
+    property_path: 'search_api_reverse_entity_references_node__field_apartments:field_completion_date'
+    type: asu_date_time
   project_construction_materials:
     label: 'Construction materials'
     datasource_id: 'entity:node'
     property_path: 'search_api_reverse_entity_references_node__field_apartments:field_construction_materials'
     type: asu_tidtotermname
+  project_construction_year:
+    label: 'Completion date'
+    datasource_id: 'entity:node'
+    property_path: 'search_api_reverse_entity_references_node__field_apartments:field_construction_year'
+    type: integer
   project_constructor:
     label: Constructor
     datasource_id: 'entity:node'
@@ -622,16 +632,6 @@ field_settings:
     datasource_id: 'entity:node'
     property_path: 'search_api_reverse_entity_references_node__field_apartments:field_estimated_completion_date'
     type: asu_date_time
-  project_completion_date:
-    label: 'Completion date'
-    datasource_id: 'entity:node'
-    property_path: 'search_api_reverse_entity_references_node__field_apartments:field_completion_date'
-    type: asu_date_time
-  project_construction_year:
-    label: 'Completion date'
-    datasource_id: 'entity:node'
-    property_path: 'search_api_reverse_entity_references_node__field_apartments:field_construction_year'
-    type: integer
   project_has_elevator:
     label: Elevator
     datasource_id: 'entity:node'
@@ -798,11 +798,6 @@ field_settings:
     datasource_id: 'entity:node'
     property_path: 'search_api_reverse_entity_references_node__field_apartments:field_street_address'
     type: string
-  project_use_complete_contract:
-    label: 'Use complete apartment contract'
-    datasource_id: 'entity:node'
-    property_path: 'search_api_reverse_entity_references_node__field_apartments:field_use_complete_contract'
-    type: boolean
   project_upcoming_description:
     label: 'Upcoming description'
     datasource_id: 'entity:node'

--- a/conf/cmi/search_api.index.apartment.yml
+++ b/conf/cmi/search_api.index.apartment.yml
@@ -798,6 +798,11 @@ field_settings:
     datasource_id: 'entity:node'
     property_path: 'search_api_reverse_entity_references_node__field_apartments:field_street_address'
     type: string
+  project_transfer_of_shares_date:
+    label: 'Transfer of shares date'
+    datasource_id: 'entity:node'
+    property_path: 'search_api_reverse_entity_references_node__field_apartments:field_transfer_of_shares_date'
+    type: date
   project_upcoming_description:
     label: 'Upcoming description'
     datasource_id: 'entity:node'
@@ -833,11 +838,6 @@ field_settings:
     datasource_id: 'entity:node'
     property_path: 'search_api_reverse_entity_references_node__field_apartments:field_zoning_status'
     type: string
-  project_transfer_of_shares_date:
-    label: 'Transfer of shares date'
-    datasource_id: 'entity:node'
-    property_path: 'search_api_reverse_entity_references_node__field_apartments:field_transfer_of_shares_date'
-    type: date
   publish_on_etuovi:
     label: 'Publish on etuovi'
     datasource_id: 'entity:node'

--- a/conf/cmi/search_api.index.apartment.yml
+++ b/conf/cmi/search_api.index.apartment.yml
@@ -798,6 +798,11 @@ field_settings:
     datasource_id: 'entity:node'
     property_path: 'search_api_reverse_entity_references_node__field_apartments:field_street_address'
     type: string
+  project_use_complete_contract:
+    label: 'Use complete apartment contract'
+    datasource_id: 'entity:node'
+    property_path: 'search_api_reverse_entity_references_node__field_apartments:field_use_complete_contract'
+    type: boolean
   project_upcoming_description:
     label: 'Upcoming description'
     datasource_id: 'entity:node'
@@ -808,6 +813,11 @@ field_settings:
     datasource_id: 'entity:node'
     property_path: 'search_api_reverse_entity_references_node__field_apartments:nid'
     type: asu_url
+  project_use_complete_contract:
+    label: 'Use complete apartment contract'
+    datasource_id: 'entity:node'
+    property_path: 'search_api_reverse_entity_references_node__field_apartments:field_use_complete_contract'
+    type: boolean
   project_uuid:
     label: 'Project UUID'
     datasource_id: 'entity:node'


### PR DESCRIPTION
- **ASU-1739: Add field "use_complete_contract" for project. Index it on Elasticsearch.**
- **ASU-1739: Add field_transfer_of_shares_date field to Project**
- **ASU-1739: Add field `project_transfer_of_shares_date` to elasticsearch**
Related PR: https://github.com/City-of-Helsinki/apartment-application-service/pull/496