### PR TITLE
ASU-1864: send offer email

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ This is an **Open Source Drupal project**. It serves as the content management s
 - dont say "Next I'll..." and wait for prompt, just keep going until the task is complete
 - dont use git to make commits or push
 - be sure to refresh patches.lock.json after creating/editing patches
+- the agent shall not refer to itself using human pronouns or feign a human persona. It should use **passive tense** to describe what its doing
 
 ## Security & Sensitive Data
 **STRICT RULE:** This is a public repository.

--- a/public/modules/custom/asu_api/src/Api/BackendApi/Request/MarkOfferMessageSentRequest.php
+++ b/public/modules/custom/asu_api/src/Api/BackendApi/Request/MarkOfferMessageSentRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\asu_api\Api\BackendApi\Request;
+
+use Drupal\asu_api\Api\BackendApi\Response\MarkOfferMessageSentResponse;
+use Drupal\asu_api\Api\Request;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Marks that the initial offer email was sent for an offer.
+ */
+class MarkOfferMessageSentRequest extends Request {
+
+  protected const METHOD = 'POST';
+  protected const PATH = '/v1/sales/offers/{offer_id}/mark_message_sent/';
+  protected const AUTHENTICATED = TRUE;
+
+  /**
+   * Constructor.
+   *
+   * @param int $offerId
+   *   Offer identifier.
+   */
+  public function __construct(private readonly int $offerId) {
+    $this->sender = NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPath(): string {
+    return str_replace('{offer_id}', (string) $this->offerId, parent::getPath());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function toArray(): array {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getResponse(ResponseInterface $response): MarkOfferMessageSentResponse {
+    return MarkOfferMessageSentResponse::createFromHttpResponse($response);
+  }
+
+}

--- a/public/modules/custom/asu_api/src/Api/BackendApi/Request/PendingOfferMessagesRequest.php
+++ b/public/modules/custom/asu_api/src/Api/BackendApi/Request/PendingOfferMessagesRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\asu_api\Api\BackendApi\Request;
+
+use Drupal\asu_api\Api\BackendApi\Response\PendingOfferMessagesResponse;
+use Drupal\asu_api\Api\Request;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Lists offers that need the initial offer email sent to customers.
+ */
+class PendingOfferMessagesRequest extends Request {
+
+  protected const METHOD = 'GET';
+  protected const PATH = '/v1/sales/offers/pending_messages/';
+  protected const AUTHENTICATED = TRUE;
+
+  /**
+   * Constructor.
+   */
+  public function __construct() {
+    $this->sender = NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function toArray(): array {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getResponse(ResponseInterface $response): PendingOfferMessagesResponse {
+    return PendingOfferMessagesResponse::createFromHttpResponse($response);
+  }
+
+}

--- a/public/modules/custom/asu_api/src/Api/BackendApi/Response/MarkOfferMessageSentResponse.php
+++ b/public/modules/custom/asu_api/src/Api/BackendApi/Response/MarkOfferMessageSentResponse.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\asu_api\Api\BackendApi\Response;
+
+use Drupal\asu_api\Api\Response;
+use Drupal\asu_api\Exception\ApplicationRequestException;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Response for marking offer message as sent.
+ */
+class MarkOfferMessageSentResponse extends Response {
+
+  /**
+   * Response payload.
+   *
+   * @var array
+   */
+  private array $payload;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(array $payload) {
+    $this->payload = $payload;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getContent(): array {
+    return $this->payload;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createFromHttpResponse(ResponseInterface $response): self {
+    if (!self::requestOk($response)) {
+      throw new ApplicationRequestException(
+        'Bad status code: ' . $response->getStatusCode()
+      );
+    }
+    $content = json_decode($response->getBody()->getContents(), TRUE);
+    return new self(is_array($content) ? $content : []);
+  }
+
+}

--- a/public/modules/custom/asu_api/src/Api/BackendApi/Response/PendingOfferMessagesResponse.php
+++ b/public/modules/custom/asu_api/src/Api/BackendApi/Response/PendingOfferMessagesResponse.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\asu_api\Api\BackendApi\Response;
+
+use Drupal\asu_api\Api\Response;
+use Drupal\asu_api\Exception\ApplicationRequestException;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Response for pending offer messages list.
+ */
+class PendingOfferMessagesResponse extends Response {
+
+  /**
+   * Message items.
+   *
+   * @var array
+   */
+  private array $items;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(array $items) {
+    $this->items = $items;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getContent(): array {
+    return $this->items;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createFromHttpResponse(ResponseInterface $response): self {
+    if (!self::requestOk($response)) {
+      throw new ApplicationRequestException(
+        'Bad status code: ' . $response->getStatusCode()
+      );
+    }
+    $content = json_decode($response->getBody()->getContents(), TRUE);
+    return new self(is_array($content) ? $content : []);
+  }
+
+}

--- a/public/modules/custom/asu_application/asu_application.module
+++ b/public/modules/custom/asu_application/asu_application.module
@@ -429,6 +429,7 @@ function asu_application_mail(string $key, array &$message, array $params) {
 
     case 'offer_created_notification':
       $message['from'] = \Drupal::config('system.site')->get('mail');
+      $message['headers']['Content-Type'] = 'text/plain; charset=UTF-8';
       $message['subject'] = OfferMailTestLabel::prefixSubject(
         $params['subject'] ?? ''
       );

--- a/public/modules/custom/asu_application/asu_application.module
+++ b/public/modules/custom/asu_application/asu_application.module
@@ -359,6 +359,15 @@ function asu_application_cron() {
     );
   }
 
+  try {
+    \Drupal::service('asu_application.offer_message')->processDueMessages();
+  }
+  catch (\Exception $e) {
+    \Drupal::logger('asu_application_cron')->critical(
+      'Unable to process offer messages: ' . $e->getMessage()
+    );
+  }
+
 }
 
 /**
@@ -416,6 +425,16 @@ function asu_application_mail(string $key, array &$message, array $params) {
       ];
       $body = (string) \Drupal::service('renderer')->renderPlain($build);
       $message['body'][] = OfferMailTestLabel::prefixBody($body);
+      break;
+
+    case 'offer_created_notification':
+      $message['from'] = \Drupal::config('system.site')->get('mail');
+      $message['subject'] = OfferMailTestLabel::prefixSubject(
+        $params['subject'] ?? ''
+      );
+      $message['body'][] = OfferMailTestLabel::prefixBody(
+        (string) ($params['body'] ?? '')
+      );
       break;
   }
 }

--- a/public/modules/custom/asu_application/asu_application.services.yml
+++ b/public/modules/custom/asu_application/asu_application.services.yml
@@ -47,5 +47,4 @@ services:
     arguments:
       - '@asu_api.backendapi'
       - '@asu_application.offer_notification'
-      - '@state'
       - '@logger.channel.asu_application'

--- a/public/modules/custom/asu_application/asu_application.services.yml
+++ b/public/modules/custom/asu_application/asu_application.services.yml
@@ -41,3 +41,11 @@ services:
       - '@entity.repository'
       - '@state'
       - '@logger.channel.asu_application'
+
+  asu_application.offer_message:
+    class: Drupal\asu_application\Service\OfferMessageService
+    arguments:
+      - '@asu_api.backendapi'
+      - '@asu_application.offer_notification'
+      - '@state'
+      - '@logger.channel.asu_application'

--- a/public/modules/custom/asu_application/src/Service/OfferMessageService.php
+++ b/public/modules/custom/asu_application/src/Service/OfferMessageService.php
@@ -9,6 +9,10 @@ use Drupal\Core\Logger\LoggerChannelInterface;
 
 /**
  * Polls Django for pending offer emails and sends them to customers.
+ *
+ * Django claims offers when listing pending messages, so this service only
+ * delivers mail for returned items. Incomplete payloads are marked sent so
+ * cron does not retry them forever.
  */
 class OfferMessageService {
 
@@ -55,6 +59,9 @@ class OfferMessageService {
         'Skipping offer message @id: missing subject, body, or recipients.',
         ['@id' => $offerId]
       );
+      if ($offerId > 0) {
+        $this->markMessageSent($offerId);
+      }
       return;
     }
 
@@ -66,16 +73,29 @@ class OfferMessageService {
       );
       if (!$sent) {
         $this->logger->error(
-          'Offer message mail failed for offer @id; will retry on next cron.',
+          'Offer message mail failed for offer @id after claim; will not retry automatically.',
           ['@id' => $offerId]
         );
-        return;
       }
-      $this->backendApi->send(new MarkOfferMessageSentRequest($offerId));
     }
     catch (\Exception $exception) {
       $this->logger->error(
         'Failed offer message for offer @id: @message',
+        ['@id' => $offerId, '@message' => $exception->getMessage()]
+      );
+    }
+  }
+
+  /**
+   * Mark an incomplete offer message as sent in Django.
+   */
+  private function markMessageSent(int $offerId): void {
+    try {
+      $this->backendApi->send(new MarkOfferMessageSentRequest($offerId));
+    }
+    catch (\Exception $exception) {
+      $this->logger->error(
+        'Failed to mark incomplete offer message @id as sent: @message',
         ['@id' => $offerId, '@message' => $exception->getMessage()]
       );
     }

--- a/public/modules/custom/asu_application/src/Service/OfferMessageService.php
+++ b/public/modules/custom/asu_application/src/Service/OfferMessageService.php
@@ -6,14 +6,11 @@ use Drupal\asu_api\Api\BackendApi\BackendApi;
 use Drupal\asu_api\Api\BackendApi\Request\MarkOfferMessageSentRequest;
 use Drupal\asu_api\Api\BackendApi\Request\PendingOfferMessagesRequest;
 use Drupal\Core\Logger\LoggerChannelInterface;
-use Drupal\Core\State\StateInterface;
 
 /**
  * Polls Django for pending offer emails and sends them to customers.
  */
 class OfferMessageService {
-
-  public const STATE_KEY_LAST_RUN = 'asu_application.offer_messages.last_run_date';
 
   /**
    * Constructor.
@@ -21,19 +18,13 @@ class OfferMessageService {
   public function __construct(
     private readonly BackendApi $backendApi,
     private readonly OfferNotificationService $offerNotification,
-    private readonly StateInterface $state,
     private readonly LoggerChannelInterface $logger,
   ) {}
 
   /**
-   * Process pending offer messages if not already run today.
+   * Process pending offer messages on every cron run.
    */
   public function processDueMessages(): void {
-    $today = date('Y-m-d');
-    if ($this->state->get(self::STATE_KEY_LAST_RUN) === $today) {
-      return;
-    }
-
     try {
       $response = $this->backendApi->send(new PendingOfferMessagesRequest());
       $messages = $response?->getContent() ?? [];
@@ -49,8 +40,6 @@ class OfferMessageService {
     foreach ($messages as $message) {
       $this->processSingleMessage($message);
     }
-
-    $this->state->set(self::STATE_KEY_LAST_RUN, $today);
   }
 
   /**
@@ -70,11 +59,18 @@ class OfferMessageService {
     }
 
     try {
-      $this->offerNotification->sendOfferCreatedNotification(
+      $sent = $this->offerNotification->sendOfferCreatedNotification(
         $recipients,
         $subject,
         $body,
       );
+      if (!$sent) {
+        $this->logger->error(
+          'Offer message mail failed for offer @id; will retry on next cron.',
+          ['@id' => $offerId]
+        );
+        return;
+      }
       $this->backendApi->send(new MarkOfferMessageSentRequest($offerId));
     }
     catch (\Exception $exception) {

--- a/public/modules/custom/asu_application/src/Service/OfferMessageService.php
+++ b/public/modules/custom/asu_application/src/Service/OfferMessageService.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Drupal\asu_application\Service;
+
+use Drupal\asu_api\Api\BackendApi\BackendApi;
+use Drupal\asu_api\Api\BackendApi\Request\MarkOfferMessageSentRequest;
+use Drupal\asu_api\Api\BackendApi\Request\PendingOfferMessagesRequest;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\State\StateInterface;
+
+/**
+ * Polls Django for pending offer emails and sends them to customers.
+ */
+class OfferMessageService {
+
+  public const STATE_KEY_LAST_RUN = 'asu_application.offer_messages.last_run_date';
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    private readonly BackendApi $backendApi,
+    private readonly OfferNotificationService $offerNotification,
+    private readonly StateInterface $state,
+    private readonly LoggerChannelInterface $logger,
+  ) {}
+
+  /**
+   * Process pending offer messages if not already run today.
+   */
+  public function processDueMessages(): void {
+    $today = date('Y-m-d');
+    if ($this->state->get(self::STATE_KEY_LAST_RUN) === $today) {
+      return;
+    }
+
+    try {
+      $response = $this->backendApi->send(new PendingOfferMessagesRequest());
+      $messages = $response?->getContent() ?? [];
+    }
+    catch (\Exception $exception) {
+      $this->logger->error(
+        'Failed to fetch pending offer messages: @message',
+        ['@message' => $exception->getMessage()]
+      );
+      return;
+    }
+
+    foreach ($messages as $message) {
+      $this->processSingleMessage($message);
+    }
+
+    $this->state->set(self::STATE_KEY_LAST_RUN, $today);
+  }
+
+  /**
+   * Process a single offer message item.
+   */
+  private function processSingleMessage(array $message): void {
+    $offerId = (int) ($message['id'] ?? 0);
+    $subject = (string) ($message['subject'] ?? '');
+    $body = (string) ($message['body'] ?? '');
+    $recipients = $this->resolveRecipientEmails($message['recipients'] ?? []);
+    if ($offerId <= 0 || $subject === '' || $body === '' || $recipients === '') {
+      $this->logger->warning(
+        'Skipping offer message @id: missing subject, body, or recipients.',
+        ['@id' => $offerId]
+      );
+      return;
+    }
+
+    try {
+      $this->offerNotification->sendOfferCreatedNotification(
+        $recipients,
+        $subject,
+        $body,
+      );
+      $this->backendApi->send(new MarkOfferMessageSentRequest($offerId));
+    }
+    catch (\Exception $exception) {
+      $this->logger->error(
+        'Failed offer message for offer @id: @message',
+        ['@id' => $offerId, '@message' => $exception->getMessage()]
+      );
+    }
+  }
+
+  /**
+   * Build comma-separated recipient list from Django payload.
+   */
+  private function resolveRecipientEmails(array $recipients): string {
+    $emails = [];
+    foreach ($recipients as $recipient) {
+      if (!is_array($recipient)) {
+        continue;
+      }
+      $email = trim((string) ($recipient['email'] ?? ''));
+      if ($email !== '') {
+        $emails[] = $email;
+      }
+    }
+    return implode(',', array_unique($emails));
+  }
+
+}

--- a/public/modules/custom/asu_application/src/Service/OfferNotificationService.php
+++ b/public/modules/custom/asu_application/src/Service/OfferNotificationService.php
@@ -94,21 +94,24 @@ class OfferNotificationService {
 
   /**
    * Send the initial offer email to customer recipients.
+   *
+   * @return bool
+   *   TRUE when the mail plugin reported a successful send.
    */
   public function sendOfferCreatedNotification(
     string $recipients,
     string $subject,
     string $body,
-  ): void {
+  ): bool {
     if ($recipients === '') {
       $this->logger->warning(
         'Skipped offer_created_notification: no recipient emails.'
       );
-      return;
+      return FALSE;
     }
 
     $langcode = $this->languageManager->getDefaultLanguage()->getId();
-    $this->mailManager->mail(
+    $result = $this->mailManager->mail(
       'asu_application',
       'offer_created_notification',
       $recipients,
@@ -120,6 +123,8 @@ class OfferNotificationService {
       NULL,
       TRUE,
     );
+
+    return !empty($result['result']);
   }
 
   /**

--- a/public/modules/custom/asu_application/src/Service/OfferNotificationService.php
+++ b/public/modules/custom/asu_application/src/Service/OfferNotificationService.php
@@ -93,6 +93,36 @@ class OfferNotificationService {
   }
 
   /**
+   * Send the initial offer email to customer recipients.
+   */
+  public function sendOfferCreatedNotification(
+    string $recipients,
+    string $subject,
+    string $body,
+  ): void {
+    if ($recipients === '') {
+      $this->logger->warning(
+        'Skipped offer_created_notification: no recipient emails.'
+      );
+      return;
+    }
+
+    $langcode = $this->languageManager->getDefaultLanguage()->getId();
+    $this->mailManager->mail(
+      'asu_application',
+      'offer_created_notification',
+      $recipients,
+      $langcode,
+      [
+        'subject' => $subject,
+        'body' => $body,
+      ],
+      NULL,
+      TRUE,
+    );
+  }
+
+  /**
    * Send a salesperson notification email.
    */
   private function sendNotification(

--- a/public/modules/custom/asu_application/src/Service/OfferNotificationService.php
+++ b/public/modules/custom/asu_application/src/Service/OfferNotificationService.php
@@ -124,7 +124,22 @@ class OfferNotificationService {
       TRUE,
     );
 
-    return !empty($result['result']);
+    return $this->wasMailSentSuccessfully($result);
+  }
+
+  /**
+   * Determine whether mail delivery should be treated as successful.
+   *
+   * In local dev, asu_content_mail_alter logs outgoing mail and blocks send,
+   * which makes the mail plugin report failure even though the message was
+   * generated correctly.
+   */
+  private function wasMailSentSuccessfully(array $result): bool {
+    if (!empty($result['result'])) {
+      return TRUE;
+    }
+
+    return getenv('APP_ENV') === 'dev';
   }
 
   /**

--- a/public/modules/custom/asu_application/tests/src/Unit/OfferMessageServiceTest.php
+++ b/public/modules/custom/asu_application/tests/src/Unit/OfferMessageServiceTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Drupal\Tests\asu_application\Unit;
+
+use Drupal\asu_api\Api\BackendApi\BackendApi;
+use Drupal\asu_api\Api\BackendApi\Response\MarkOfferMessageSentResponse;
+use Drupal\asu_api\Api\BackendApi\Response\PendingOfferMessagesResponse;
+use Drupal\asu_application\Service\OfferMessageService;
+use Drupal\asu_application\Service\OfferNotificationService;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests OfferMessageService cron logic.
+ *
+ * @group asu_application
+ */
+final class OfferMessageServiceTest extends UnitTestCase {
+
+  /**
+   * Daily throttle prevents a second run on the same day.
+   */
+  public function testDailyThrottleSkipsSecondRun(): void {
+    $state = $this->createMock(StateInterface::class);
+    $state->expects($this->once())
+      ->method('get')
+      ->with(OfferMessageService::STATE_KEY_LAST_RUN)
+      ->willReturn(date('Y-m-d'));
+
+    $backend = $this->createMock(BackendApi::class);
+    $backend->expects($this->never())->method('send');
+
+    $service = new OfferMessageService(
+      $backend,
+      $this->createMock(OfferNotificationService::class),
+      $state,
+      $this->createMock(LoggerChannelInterface::class),
+    );
+
+    $service->processDueMessages();
+  }
+
+  /**
+   * Processes messages and marks them sent in Django.
+   */
+  public function testProcessesMessagesAndMarksSent(): void {
+    $state = $this->createMock(StateInterface::class);
+    $state->expects($this->once())->method('get')->willReturn('2000-01-01');
+    $state->expects($this->once())->method('set')->with(
+      OfferMessageService::STATE_KEY_LAST_RUN,
+      date('Y-m-d')
+    );
+
+    $notification = $this->createMock(OfferNotificationService::class);
+    $notification->expects($this->exactly(2))
+      ->method('sendOfferCreatedNotification')
+      ->with(
+        $this->logicalOr('a@example.com', 'b@example.com,c@example.com'),
+        $this->isType('string'),
+        $this->isType('string'),
+      );
+
+    $backend = $this->createMock(BackendApi::class);
+    $backend->expects($this->exactly(3))
+      ->method('send')
+      ->willReturnOnConsecutiveCalls(
+        new PendingOfferMessagesResponse([
+          [
+            'id' => 1,
+            'subject' => 'Tarjous As Oy 1',
+            'body' => 'Offer body one',
+            'recipients' => [
+              ['name' => 'A', 'email' => 'a@example.com'],
+            ],
+          ],
+          [
+            'id' => 2,
+            'subject' => 'Tarjous As Oy 2',
+            'body' => 'Offer body two',
+            'recipients' => [
+              ['name' => 'B', 'email' => 'b@example.com'],
+              ['name' => 'C', 'email' => 'c@example.com'],
+            ],
+          ],
+        ]),
+        new MarkOfferMessageSentResponse(['id' => 1]),
+        new MarkOfferMessageSentResponse(['id' => 2]),
+      );
+
+    $service = new OfferMessageService(
+      $backend,
+      $notification,
+      $state,
+      $this->createMock(LoggerChannelInterface::class),
+    );
+
+    $service->processDueMessages();
+  }
+
+}

--- a/public/modules/custom/asu_application/tests/src/Unit/OfferMessageServiceTest.php
+++ b/public/modules/custom/asu_application/tests/src/Unit/OfferMessageServiceTest.php
@@ -18,9 +18,9 @@ use Drupal\Tests\UnitTestCase;
 final class OfferMessageServiceTest extends UnitTestCase {
 
   /**
-   * Processes messages and marks them sent only after successful mail.
+   * Sends claimed pending messages without calling mark again.
    */
-  public function testProcessesMessagesAndMarksSent(): void {
+  public function testProcessesClaimedMessagesWithoutRemaking(): void {
     $notification = $this->createMock(OfferNotificationService::class);
     $notification->expects($this->exactly(2))
       ->method('sendOfferCreatedNotification')
@@ -41,31 +41,27 @@ final class OfferMessageServiceTest extends UnitTestCase {
       });
 
     $backend = $this->createMock(BackendApi::class);
-    $backend->expects($this->exactly(3))
+    $backend->expects($this->once())
       ->method('send')
-      ->willReturnOnConsecutiveCalls(
-        new PendingOfferMessagesResponse([
-          [
-            'id' => 1,
-            'subject' => 'Tarjous As Oy 1',
-            'body' => 'Offer body one',
-            'recipients' => [
-              ['name' => 'A', 'email' => 'a@example.com'],
-            ],
+      ->willReturn(new PendingOfferMessagesResponse([
+        [
+          'id' => 1,
+          'subject' => 'Tarjous As Oy 1',
+          'body' => 'Offer body one',
+          'recipients' => [
+            ['name' => 'A', 'email' => 'a@example.com'],
           ],
-          [
-            'id' => 2,
-            'subject' => 'Tarjous As Oy 2',
-            'body' => 'Offer body two',
-            'recipients' => [
-              ['name' => 'B', 'email' => 'b@example.com'],
-              ['name' => 'C', 'email' => 'c@example.com'],
-            ],
+        ],
+        [
+          'id' => 2,
+          'subject' => 'Tarjous As Oy 2',
+          'body' => 'Offer body two',
+          'recipients' => [
+            ['name' => 'B', 'email' => 'b@example.com'],
+            ['name' => 'C', 'email' => 'c@example.com'],
           ],
-        ]),
-        new MarkOfferMessageSentResponse(['id' => 1]),
-        new MarkOfferMessageSentResponse(['id' => 2]),
-      );
+        ],
+      ]));
 
     $service = new OfferMessageService(
       $backend,
@@ -77,9 +73,9 @@ final class OfferMessageServiceTest extends UnitTestCase {
   }
 
   /**
-   * Does not mark sent when mail delivery fails.
+   * Logs mail failure after Django has already claimed the offer.
    */
-  public function testDoesNotMarkSentWhenMailFails(): void {
+  public function testLogsErrorWhenMailFailsAfterClaim(): void {
     $notification = $this->createMock(OfferNotificationService::class);
     $notification->expects($this->once())
       ->method('sendOfferCreatedNotification')
@@ -101,6 +97,41 @@ final class OfferMessageServiceTest extends UnitTestCase {
 
     $logger = $this->createMock(LoggerChannelInterface::class);
     $logger->expects($this->once())->method('error');
+
+    $service = new OfferMessageService(
+      $backend,
+      $notification,
+      $logger,
+    );
+
+    $service->processDueMessages();
+  }
+
+  /**
+   * Marks incomplete payloads as sent so cron does not retry forever.
+   */
+  public function testMarksSentWhenSkippingIncompleteMessage(): void {
+    $notification = $this->createMock(OfferNotificationService::class);
+    $notification->expects($this->never())
+      ->method('sendOfferCreatedNotification');
+
+    $backend = $this->createMock(BackendApi::class);
+    $backend->expects($this->exactly(2))
+      ->method('send')
+      ->willReturnOnConsecutiveCalls(
+        new PendingOfferMessagesResponse([
+          [
+            'id' => 1,
+            'subject' => 'Tarjous As Oy 1',
+            'body' => 'Offer body one',
+            'recipients' => [],
+          ],
+        ]),
+        new MarkOfferMessageSentResponse(['id' => 1]),
+      );
+
+    $logger = $this->createMock(LoggerChannelInterface::class);
+    $logger->expects($this->once())->method('warning');
 
     $service = new OfferMessageService(
       $backend,

--- a/public/modules/custom/asu_application/tests/src/Unit/OfferMessageServiceTest.php
+++ b/public/modules/custom/asu_application/tests/src/Unit/OfferMessageServiceTest.php
@@ -8,7 +8,6 @@ use Drupal\asu_api\Api\BackendApi\Response\PendingOfferMessagesResponse;
 use Drupal\asu_application\Service\OfferMessageService;
 use Drupal\asu_application\Service\OfferNotificationService;
 use Drupal\Core\Logger\LoggerChannelInterface;
-use Drupal\Core\State\StateInterface;
 use Drupal\Tests\UnitTestCase;
 
 /**
@@ -19,47 +18,27 @@ use Drupal\Tests\UnitTestCase;
 final class OfferMessageServiceTest extends UnitTestCase {
 
   /**
-   * Daily throttle prevents a second run on the same day.
-   */
-  public function testDailyThrottleSkipsSecondRun(): void {
-    $state = $this->createMock(StateInterface::class);
-    $state->expects($this->once())
-      ->method('get')
-      ->with(OfferMessageService::STATE_KEY_LAST_RUN)
-      ->willReturn(date('Y-m-d'));
-
-    $backend = $this->createMock(BackendApi::class);
-    $backend->expects($this->never())->method('send');
-
-    $service = new OfferMessageService(
-      $backend,
-      $this->createMock(OfferNotificationService::class),
-      $state,
-      $this->createMock(LoggerChannelInterface::class),
-    );
-
-    $service->processDueMessages();
-  }
-
-  /**
-   * Processes messages and marks them sent in Django.
+   * Processes messages and marks them sent only after successful mail.
    */
   public function testProcessesMessagesAndMarksSent(): void {
-    $state = $this->createMock(StateInterface::class);
-    $state->expects($this->once())->method('get')->willReturn('2000-01-01');
-    $state->expects($this->once())->method('set')->with(
-      OfferMessageService::STATE_KEY_LAST_RUN,
-      date('Y-m-d')
-    );
-
     $notification = $this->createMock(OfferNotificationService::class);
     $notification->expects($this->exactly(2))
       ->method('sendOfferCreatedNotification')
-      ->with(
-        $this->logicalOr('a@example.com', 'b@example.com,c@example.com'),
-        $this->isType('string'),
-        $this->isType('string'),
-      );
+      ->willReturnCallback(function (string $recipients, string $subject, string $body): bool {
+        static $call = 0;
+        $call++;
+        if ($call === 1) {
+          $this->assertSame('a@example.com', $recipients);
+          $this->assertSame('Tarjous As Oy 1', $subject);
+          $this->assertSame('Offer body one', $body);
+        }
+        else {
+          $this->assertSame('b@example.com,c@example.com', $recipients);
+          $this->assertSame('Tarjous As Oy 2', $subject);
+          $this->assertSame('Offer body two', $body);
+        }
+        return TRUE;
+      });
 
     $backend = $this->createMock(BackendApi::class);
     $backend->expects($this->exactly(3))
@@ -91,8 +70,42 @@ final class OfferMessageServiceTest extends UnitTestCase {
     $service = new OfferMessageService(
       $backend,
       $notification,
-      $state,
       $this->createMock(LoggerChannelInterface::class),
+    );
+
+    $service->processDueMessages();
+  }
+
+  /**
+   * Does not mark sent when mail delivery fails.
+   */
+  public function testDoesNotMarkSentWhenMailFails(): void {
+    $notification = $this->createMock(OfferNotificationService::class);
+    $notification->expects($this->once())
+      ->method('sendOfferCreatedNotification')
+      ->willReturn(FALSE);
+
+    $backend = $this->createMock(BackendApi::class);
+    $backend->expects($this->once())
+      ->method('send')
+      ->willReturn(new PendingOfferMessagesResponse([
+        [
+          'id' => 1,
+          'subject' => 'Tarjous As Oy 1',
+          'body' => 'Offer body one',
+          'recipients' => [
+            ['name' => 'A', 'email' => 'a@example.com'],
+          ],
+        ],
+      ]));
+
+    $logger = $this->createMock(LoggerChannelInterface::class);
+    $logger->expects($this->once())->method('error');
+
+    $service = new OfferMessageService(
+      $backend,
+      $notification,
+      $logger,
     );
 
     $service->processDueMessages();

--- a/public/modules/custom/asu_application/tests/src/Unit/OfferNotificationServiceTest.php
+++ b/public/modules/custom/asu_application/tests/src/Unit/OfferNotificationServiceTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Drupal\Tests\asu_application\Unit;
+
+use Drupal\asu_application\Service\OfferNotificationService;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Mail\MailManagerInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests OfferNotificationService mail success handling.
+ *
+ * @group asu_application
+ */
+final class OfferNotificationServiceTest extends UnitTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown(): void {
+    putenv('APP_ENV');
+    parent::tearDown();
+  }
+
+  /**
+   * Console-logged dev mail is treated as successful delivery.
+   */
+  public function testDevConsoleMailCountsAsSuccess(): void {
+    putenv('APP_ENV=dev');
+
+    $mailManager = $this->createMock(MailManagerInterface::class);
+    $mailManager->expects($this->once())
+      ->method('mail')
+      ->willReturn(['result' => FALSE]);
+
+    $language = $this->createMock(LanguageInterface::class);
+    $language->method('getId')->willReturn('fi');
+
+    $languageManager = $this->createMock(LanguageManagerInterface::class);
+    $languageManager->method('getDefaultLanguage')->willReturn($language);
+
+    $service = new OfferNotificationService(
+      $mailManager,
+      $languageManager,
+      $this->createMock(EntityTypeManagerInterface::class),
+      $this->createMock(EntityRepositoryInterface::class),
+      $this->createMock(LoggerChannelInterface::class),
+    );
+
+    $this->assertTrue($service->sendOfferCreatedNotification(
+      'customer@example.com',
+      'Tarjous',
+      'Body',
+    ));
+  }
+
+  /**
+   * Failed mail outside dev is not treated as successful delivery.
+   */
+  public function testFailedMailOutsideDevIsNotSuccess(): void {
+    putenv('APP_ENV=production');
+
+    $mailManager = $this->createMock(MailManagerInterface::class);
+    $mailManager->expects($this->once())
+      ->method('mail')
+      ->willReturn(['result' => FALSE]);
+
+    $language = $this->createMock(LanguageInterface::class);
+    $language->method('getId')->willReturn('fi');
+
+    $languageManager = $this->createMock(LanguageManagerInterface::class);
+    $languageManager->method('getDefaultLanguage')->willReturn($language);
+
+    $service = new OfferNotificationService(
+      $mailManager,
+      $languageManager,
+      $this->createMock(EntityTypeManagerInterface::class),
+      $this->createMock(EntityRepositoryInterface::class),
+      $this->createMock(LoggerChannelInterface::class),
+    );
+
+    $this->assertFalse($service->sendOfferCreatedNotification(
+      'customer@example.com',
+      'Tarjous',
+      'Body',
+    ));
+  }
+
+}


### PR DESCRIPTION
- **ASU-1864: Add feature for sending email when pending offer is created for customer**

related PR's
- Django: City-of-Helsinki/apartment-application-service/pull/614
- Frontend: City-of-Helsinki/att-sales-ui/pull/218